### PR TITLE
Add new NN model and fix bug.

### DIFF
--- a/nn_dataflow/core/loop_blocking_scheme.py
+++ b/nn_dataflow/core/loop_blocking_scheme.py
@@ -143,13 +143,7 @@ class LoopBlockingScheme(object):
         self.src_is_dram = (resource.src_data_region.type == NodeRegion.DRAM)
         self.dst_is_dram = (resource.dst_data_region.type == NodeRegion.DRAM)
 
-        # Check resource for filter pinning.
         self.filter_pinned = False
-        if resource.no_time_mux:
-            if all(self.bl_ts[0][lpe] == 1 for lpe
-                   in self.nld.data_loops[de.FIL].loops()):
-                self.filter_pinned = True
-                self.fetch[0][de.FIL] = 0
 
         # If data regions are not DRAM, can only access once, no spilling.
         if not self.src_is_dram:
@@ -214,6 +208,13 @@ class LoopBlockingScheme(object):
 
         # Remote gbuf access.
         self.remote_gbuf_access = [0.] * de.NUM
+
+        # Check resource for filter pinning.
+        if resource.no_time_mux:
+            if all(self.bl_ts[0][lpe] == 1 for lpe
+                   in self.nld.data_loops[de.FIL].loops()):
+                self.filter_pinned = True
+                self.fetch[0][de.FIL] = 0
 
     def is_valid(self):
         '''

--- a/nn_dataflow/core/nn_dataflow.py
+++ b/nn_dataflow/core/nn_dataflow.py
@@ -325,23 +325,12 @@ class NNDataflow(object):
                 regions=(input_region,),
                 parts=(part.projection(input_region, appl2frng=True),))
 
-            if ext_layers:
-                for ext_parts in itertools.product(
-                        *[partition.gen_partition(ext_layer, self.batch_size,
-                                                  ext_region.dim, options,
-                                                  guaranteed=True)
-                          for ext_layer in ext_layers]):
-                    ext_layout_dict = dict(zip(
-                        ext_layer_names,
-                        [DataLayout(
-                            frngs=(ext_frng,),
-                            regions=(ext_region,),
-                            parts=(ext_part.projection(ext_region,
-                                                       appl2frng=True),))
-                         for ext_part, ext_frng in zip(ext_parts, ext_frngs)]))
+            ext_layout_dict = dict(zip(
+                ext_layer_names,
+                [DataLayout(
+                    frngs=(ext_frng,),
+                    regions=(ext_region,),
+                    parts=(part.projection(ext_region, appl2frng=True),))
+                 for ext_frng in ext_frngs])) if ext_layers else None
 
-                    yield input_layout, ext_layout_dict
-
-            else:
-                yield input_layout, None
-
+            yield input_layout, ext_layout_dict

--- a/nn_dataflow/nns/resnet50.py
+++ b/nn_dataflow/nns/resnet50.py
@@ -1,0 +1,95 @@
+""" $lic$
+Copyright (C) 2016-2019 by The Board of Trustees of Stanford University
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the Modified BSD-3 License as published by the Open Source
+Initiative.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the BSD-3 License for more details.
+
+You should have received a copy of the Modified BSD-3 License along with this
+program. If not, see <https://opensource.org/licenses/BSD-3-Clause>.
+"""
+
+from nn_dataflow.core import Network
+from nn_dataflow.core import InputLayer, ConvLayer, FCLayer, \
+        PoolingLayer, EltwiseLayer
+
+'''
+ResNet-50
+
+He, Zhang, Ren, and Sun, 2015
+'''
+
+NN = Network('ResNet')
+
+NN.set_input_layer(InputLayer(3, 224))
+
+NN.add('conv1', ConvLayer(3, 64, 112, 7, 2))
+NN.add('pool1', PoolingLayer(64, 56, 3, 2))
+
+RES_PREV = 'pool1'
+
+for i in range(3):
+    NN.add('conv2_{}_a'.format(i), ConvLayer(64 if i == 0 else 256, 64, 56, 1))
+    NN.add('conv2_{}_b'.format(i), ConvLayer(64, 64, 56, 3))
+    NN.add('conv2_{}_c'.format(i), ConvLayer(64, 256, 56, 1))
+
+    # With residual shortcut.
+    if i == 0:
+        NN.add('conv2_br', ConvLayer(64, 256, 56, 1), prevs=(RES_PREV,))
+        RES_PREV = 'conv2_br'
+    NN.add('conv2_{}_res'.format(i), EltwiseLayer(256, 56, 2),
+           prevs=(RES_PREV, 'conv2_{}_c'.format(i)))
+    RES_PREV = 'conv2_{}_res'.format(i)
+
+for i in range(4):
+    NN.add('conv3_{}_a'.format(i),
+           ConvLayer(256, 128, 28, 1, 2) if i == 0
+           else ConvLayer(512, 128, 28, 1))
+    NN.add('conv3_{}_b'.format(i), ConvLayer(128, 128, 28, 3))
+    NN.add('conv3_{}_c'.format(i), ConvLayer(128, 512, 28, 1))
+
+    # With residual shortcut.
+    if i == 0:
+        NN.add('conv3_br', ConvLayer(256, 512, 28, 1, 2), prevs=(RES_PREV,))
+        RES_PREV = 'conv3_br'
+    NN.add('conv3_{}_res'.format(i), EltwiseLayer(512, 28, 2),
+           prevs=(RES_PREV, 'conv3_{}_c'.format(i)))
+    RES_PREV = 'conv3_{}_res'.format(i)
+
+for i in range(6):
+    NN.add('conv4_{}_a'.format(i),
+           ConvLayer(512, 256, 14, 1, 2) if i == 0
+           else ConvLayer(1024, 256, 14, 1))
+    NN.add('conv4_{}_b'.format(i), ConvLayer(256, 256, 14, 3))
+    NN.add('conv4_{}_c'.format(i), ConvLayer(256, 1024, 14, 1))
+
+    # With residual shortcut.
+    if i == 0:
+        NN.add('conv4_br', ConvLayer(512, 1024, 14, 1, 2), prevs=(RES_PREV,))
+        RES_PREV = 'conv4_br'
+    NN.add('conv4_{}_res'.format(i), EltwiseLayer(1024, 14, 2),
+           prevs=(RES_PREV, 'conv4_{}_c'.format(i)))
+    RES_PREV = 'conv4_{}_res'.format(i)
+
+for i in range(3):
+    NN.add('conv5_{}_a'.format(i),
+           ConvLayer(1024, 512, 7, 1, 2) if i == 0
+           else ConvLayer(2048, 512, 7, 1))
+    NN.add('conv5_{}_b'.format(i), ConvLayer(512, 512, 7, 3))
+    NN.add('conv5_{}_c'.format(i), ConvLayer(512, 2048, 7, 1))
+
+    # With residual shortcut.
+    if i == 0:
+        NN.add('conv5_br', ConvLayer(1024, 2048, 7, 1, 2), prevs=(RES_PREV,))
+        RES_PREV = 'conv5_br'
+    NN.add('conv5_{}_res'.format(i), EltwiseLayer(2048, 7, 2),
+           prevs=(RES_PREV, 'conv5_{}_c'.format(i)))
+    RES_PREV = 'conv5_{}_res'.format(i)
+
+NN.add('pool5', PoolingLayer(2048, 1, 7))
+
+NN.add('fc', FCLayer(2048, 1000))

--- a/nn_dataflow/tests/unit_test/test_util.py
+++ b/nn_dataflow/tests/unit_test/test_util.py
@@ -151,21 +151,43 @@ class TestUtilApproxDividable(unittest.TestCase):
 
     def test_int(self):
         ''' Int. '''
-        self.assertTrue(util.approx_dividable(24, 2, overhead=0))
-        self.assertTrue(util.approx_dividable(24, 3, overhead=0))
-        self.assertTrue(util.approx_dividable(24, 4, overhead=0))
+        self.assertTrue(util.approx_dividable(24, 2,
+                                              rel_overhead=0, abs_overhead=0))
+        self.assertTrue(util.approx_dividable(24, 3,
+                                              rel_overhead=0, abs_overhead=0))
+        self.assertTrue(util.approx_dividable(24, 4,
+                                              rel_overhead=0, abs_overhead=0))
 
         self.assertTrue(util.approx_dividable(11, 2))
-        self.assertFalse(util.approx_dividable(9, 2))
+        self.assertFalse(util.approx_dividable(8, 5))
         self.assertTrue(util.approx_dividable(19, 5))
 
-        self.assertTrue(util.approx_dividable(7, 2, overhead=0.2))
-        self.assertTrue(util.approx_dividable(19, 7, overhead=0.2))
-        self.assertFalse(util.approx_dividable(22, 7, overhead=0.2))
+        self.assertTrue(util.approx_dividable(7, 2,
+                                              rel_overhead=0.2,
+                                              abs_overhead=0))
+        self.assertTrue(util.approx_dividable(7, 2,
+                                              rel_overhead=0,
+                                              abs_overhead=1))
+        self.assertTrue(util.approx_dividable(19, 7,
+                                              rel_overhead=0.2,
+                                              abs_overhead=0))
+        self.assertTrue(util.approx_dividable(19, 7,
+                                              rel_overhead=0,
+                                              abs_overhead=2))
+        self.assertFalse(util.approx_dividable(22, 7,
+                                               rel_overhead=0.2,
+                                               abs_overhead=0))
+        self.assertFalse(util.approx_dividable(23, 7,
+                                               rel_overhead=0,
+                                               abs_overhead=1))
 
-        ovhd = util.idivc(19, 7) * 7 / 19. - 1
-        self.assertFalse(util.approx_dividable(19, 7, overhead=ovhd - 0.01))
-        self.assertTrue(util.approx_dividable(19, 7, overhead=ovhd + 0.01))
+        ovhd = (21 - 19) / max(21., 19.)
+        self.assertFalse(util.approx_dividable(19, 7,
+                                               rel_overhead=ovhd - 0.01,
+                                               abs_overhead=0))
+        self.assertTrue(util.approx_dividable(19, 7,
+                                              rel_overhead=ovhd + 0.01,
+                                              abs_overhead=0))
 
     def test_float(self):
         ''' Float. '''

--- a/nn_dataflow/util.py
+++ b/nn_dataflow/util.py
@@ -123,10 +123,14 @@ def prod(lst):
     return reduce(mul, lst, 1)
 
 
-def approx_dividable(total, num, overhead=0.1):
+def approx_dividable(total, num, rel_overhead=0.1, abs_overhead=1):
     ''' Whether it is reasonable to divide `total` into `num` parts.
-    `overhead` is the allowed max padding overhead.  '''
-    return idivc(total, num) * num <= total * (1 + overhead)
+    `rel_overhead` is the allowed max padding overhead measured
+    relatively; `abs_overhead` is the allowed max padding
+    overhead measured by absolute value.'''
+    return total >= num and isclose(
+        idivc(total, num) * num, total,
+        rel_tol=rel_overhead, abs_tol=abs_overhead)
 
 
 def factorize(value, num, limits=None):


### PR DESCRIPTION
[nns] Add ResNet-50 NN model.
[NNDataflow] Share the same partition between input layer and external layers. For layered LSTMs, the number of external layers could be quite a few (e.g., 8). The complete combination of all partition choices of these external layers is too high to explore. So we assume all input and external layers share the same partition scheme.
[util] Allow both relative and absolute overheads in approx_dividable.
[LoopBlockingScheme] Bug fix to put weight-pinning code block after buffer sharing.