### PR TITLE
Py3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ eggs/
 .eggs/
 *.egg-info/
 *.egg
+
+# Editor related.
+settings.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-    - 2.7
+    - 3.6
 
 install:
     - pip install .

--- a/nn_dataflow/core/buf_shr_scheme.py
+++ b/nn_dataflow/core/buf_shr_scheme.py
@@ -22,7 +22,7 @@ from .. import util
 from .layer import ConvLayer
 from .phy_dim2 import PhyDim2
 
-class BufShrScheme(object):
+class BufShrScheme():
     '''
     The buffer sharing scheme.
     '''

--- a/nn_dataflow/core/buf_shr_scheme.py
+++ b/nn_dataflow/core/buf_shr_scheme.py
@@ -272,7 +272,7 @@ class BufShrScheme():
         '''
         if fetch_width <= 1:
             return 0
-        elif fetch_width > subgrp_size:
+        if fetch_width > subgrp_size:
             raise ValueError('BufShrScheme: fetch width is larger than '
                              'subgroup size. {} vs. {}.'
                              .format(fetch_width, subgrp_size))

--- a/nn_dataflow/core/data_layout.py
+++ b/nn_dataflow/core/data_layout.py
@@ -131,7 +131,7 @@ class DataLayout(namedtuple('DataLayout', DATA_LAYOUT_LIST)):
                 # Each forward step, get the min-distance pair of source and
                 # destination.
                 src, dst = min(itertools.product(src_set, dst_set),
-                               key=lambda (s, d): d.hop_dist(s))
+                               key=lambda sd: sd[1].hop_dist(sd[0]))
                 dst_set.remove(dst)
                 src_set.add(dst)
                 nhops += total_size * dst.hop_dist(src)

--- a/nn_dataflow/core/fmap_range.py
+++ b/nn_dataflow/core/fmap_range.py
@@ -133,18 +133,18 @@ class FmapRange(namedtuple('FmapRange', ['fp_beg', 'fp_end'])):
                    in zip(fpos, self.fp_beg, self.fp_end))
 
     def __lt__(self, other):
-        if isinstance(other, self.__class__):
-            return self._compare(other) < 0
-        return NotImplemented
+        assert isinstance(other, self.__class__), \
+                "FmapRange: invalid type to compare: {}".format(type(other))
+        return self._compare(other) < 0
 
     def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            try:
-                return self._compare(other) == 0
-            except ValueError:
-                return False
-        return NotImplemented
-    
+        assert isinstance(other, self.__class__), \
+                "FmapRange: invalid type to compare: {}".format(type(other))
+        try:
+            return self._compare(other) == 0
+        except ValueError:
+            return False
+
     def __hash__(self):
         '''
         If a class does not define an __eq__() method, it should not define a
@@ -152,7 +152,7 @@ class FmapRange(namedtuple('FmapRange', ['fp_beg', 'fp_end'])):
         its instances will not be usable as items in hashable collections.
         See https://docs.python.org/3.1/reference/datamodel.html?highlight=hash#object.__hash__
         '''
-        return hash((self.fp_beg, self.fp_end)) 
+        return hash((self.fp_beg, self.fp_end))
 
     def _compare(self, other):
         # Identical ranges.
@@ -190,27 +190,17 @@ class FmapRange(namedtuple('FmapRange', ['fp_beg', 'fp_end'])):
 
     def __ne__(self, other):
         r = self.__eq__(other)
-        if r is NotImplemented:
-            # "not" NotImplemented will be True.
-            return r
         return not r
 
     def __gt__(self, other):
         r = self.__lt__(other)
-        if r is NotImplemented:
-            # NotImplemented "and" X will be X.
-            return r
         return not r and self.__ne__(other)
 
     def __le__(self, other):
-        # NotImplemented "or" X is safe.
         return self.__lt__(other) or self.__eq__(other)
 
     def __ge__(self, other):
         r = self.__lt__(other)
-        if r is NotImplemented:
-            # "not" NotImplemented will be True.
-            return r
         return not r
 
 

--- a/nn_dataflow/core/fmap_range.py
+++ b/nn_dataflow/core/fmap_range.py
@@ -144,6 +144,15 @@ class FmapRange(namedtuple('FmapRange', ['fp_beg', 'fp_end'])):
             except ValueError:
                 return False
         return NotImplemented
+    
+    def __hash__(self):
+        '''
+        If a class does not define an __eq__() method, it should not define a
+        __hash__() operation either; if it defines __eq__() but not __hash__(),
+        its instances will not be usable as items in hashable collections.
+        See https://docs.python.org/3.1/reference/datamodel.html?highlight=hash#object.__hash__
+        '''
+        return hash((self.fp_beg, self.fp_end)) 
 
     def _compare(self, other):
         # Identical ranges.

--- a/nn_dataflow/core/fmap_range.py
+++ b/nn_dataflow/core/fmap_range.py
@@ -129,7 +129,7 @@ class FmapRange(namedtuple('FmapRange', ['fp_beg', 'fp_end'])):
         '''
         Whether the given FmapPosition is in the FmapRange.
         '''
-        return all(p >= b and p < e for p, b, e
+        return all(b <= p < e for p, b, e
                    in zip(fpos, self.fp_beg, self.fp_end))
 
     def __lt__(self, other):
@@ -164,7 +164,7 @@ class FmapRange(namedtuple('FmapRange', ['fp_beg', 'fp_end'])):
             if other.size() == 0:
                 return 0
             return -1
-        elif other.size() == 0:
+        if other.size() == 0:
             return 1
 
         # Overlap check.

--- a/nn_dataflow/core/fmap_range.py
+++ b/nn_dataflow/core/fmap_range.py
@@ -204,7 +204,7 @@ class FmapRange(namedtuple('FmapRange', ['fp_beg', 'fp_end'])):
         return not r
 
 
-class FmapRangeMap(object):
+class FmapRangeMap():
     '''
     A map with key as type FmapPosition, and the keys within a FmapRange all
     map to the same value.

--- a/nn_dataflow/core/int_range.py
+++ b/nn_dataflow/core/int_range.py
@@ -23,7 +23,7 @@ class IntRange(namedtuple('IntRange', ['beg', 'end'])):
 
     def __new__(cls, *args, **kwargs):
         ntp = super(IntRange, cls).__new__(cls, *args, **kwargs)
-        
+
         if not isinstance(ntp.beg, numbers.Integral):
             raise TypeError('IntRange: begin value must be an integer.')
         if not isinstance(ntp.end, numbers.Integral):

--- a/nn_dataflow/core/int_range.py
+++ b/nn_dataflow/core/int_range.py
@@ -23,7 +23,6 @@ class IntRange(namedtuple('IntRange', ['beg', 'end'])):
 
     def __new__(cls, *args, **kwargs):
         ntp = super(IntRange, cls).__new__(cls, *args, **kwargs)
-
         if not isinstance(ntp.beg, numbers.Integral):
             raise TypeError('IntRange: begin value must be an integer.')
         if not isinstance(ntp.end, numbers.Integral):

--- a/nn_dataflow/core/int_range.py
+++ b/nn_dataflow/core/int_range.py
@@ -23,6 +23,7 @@ class IntRange(namedtuple('IntRange', ['beg', 'end'])):
 
     def __new__(cls, *args, **kwargs):
         ntp = super(IntRange, cls).__new__(cls, *args, **kwargs)
+        
         if not isinstance(ntp.beg, numbers.Integral):
             raise TypeError('IntRange: begin value must be an integer.')
         if not isinstance(ntp.end, numbers.Integral):

--- a/nn_dataflow/core/inter_layer_pipeline.py
+++ b/nn_dataflow/core/inter_layer_pipeline.py
@@ -20,7 +20,7 @@ from .network import Network
 from .pipeline_segment import PipelineSegment
 from .resource import Resource
 
-class InterLayerPipeline(object):
+class InterLayerPipeline():
     '''
     Inter-layer pipeline.
     '''

--- a/nn_dataflow/core/loop_blocking.py
+++ b/nn_dataflow/core/loop_blocking.py
@@ -104,7 +104,7 @@ def skip_conv(bl_ts, bl_ords):
 def _loop_blocking_cmp_key(options, cost):
     if options.opt_goal == 'ed':
         return lambda lbs: lbs.get_access_cost(cost) * lbs.time
-    elif options.opt_goal == 'd':
+    if options.opt_goal == 'd':
         return lambda lbs: (lbs.time, lbs.get_access_cost(cost))
     assert options.opt_goal == 'e'
     return lambda lbs: (lbs.get_access_cost(cost), lbs.time)
@@ -130,7 +130,6 @@ def _gen_loopblocking_perprocess(
     def _sweep():
         ''' Sweep all. '''
         is_conv_loops = (nested_loop_desc.data_loops == ConvLayer.data_loops())
-        counter = 0
         for bl_ts, bl_ords in itertools.product(_gen_bl_ts(), gen_ords):
             if is_conv_loops and skip_conv(bl_ts, bl_ords):
                 continue
@@ -139,7 +138,6 @@ def _gen_loopblocking_perprocess(
             lbs = LoopBlockingScheme(
                 nested_loop_desc, bl_ts, bl_ords, resource, bufshr,
                 options)
-            counter += 1
             yield lbs
 
     return heapq.nsmallest(options.ntops, _sweep(),

--- a/nn_dataflow/core/loop_blocking.py
+++ b/nn_dataflow/core/loop_blocking.py
@@ -130,6 +130,7 @@ def _gen_loopblocking_perprocess(
     def _sweep():
         ''' Sweep all. '''
         is_conv_loops = (nested_loop_desc.data_loops == ConvLayer.data_loops())
+        counter = 0
         for bl_ts, bl_ords in itertools.product(_gen_bl_ts(), gen_ords):
             if is_conv_loops and skip_conv(bl_ts, bl_ords):
                 continue
@@ -138,6 +139,7 @@ def _gen_loopblocking_perprocess(
             lbs = LoopBlockingScheme(
                 nested_loop_desc, bl_ts, bl_ords, resource, bufshr,
                 options)
+            counter += 1
             yield lbs
 
     return heapq.nsmallest(options.ntops, _sweep(),
@@ -187,8 +189,8 @@ def gen_loopblocking(nested_loop_desc, resource, part, constraint, cost,
         apply_func = pool.apply_async
         retrieve_func = retrieve_result()
     else:
-        pool = Pool(processes=1)
-        apply_func = pool.apply
+        pool = None
+        apply_func = util.apply
         retrieve_func = retrieve_result_st()
 
     # Exhaustive generators.

--- a/nn_dataflow/core/loop_blocking.py
+++ b/nn_dataflow/core/loop_blocking.py
@@ -15,7 +15,7 @@ program. If not, see <https://opensource.org/licenses/BSD-3-Clause>.
 
 import heapq
 import itertools
-from multiprocessing import Pool
+from multiprocessing.pool import Pool
 
 from . import loop_blocking_solver
 from . import loop_enum as le
@@ -65,7 +65,7 @@ def skip_conv(bl_ts, bl_ords):
 
     outer_level_innermost_nt_loop = None
 
-    for t_, ord_ in itertools.izip_longest(bl_ts, bl_ords, fillvalue=None):
+    for t_, ord_ in itertools.zip_longest(bl_ts, bl_ords, fillvalue=None):
 
         # Non-trivial loops.
         nt_loops = [lpe for lpe in range(le.NUM) if t_[lpe] > 1]
@@ -187,8 +187,8 @@ def gen_loopblocking(nested_loop_desc, resource, part, constraint, cost,
         apply_func = pool.apply_async
         retrieve_func = retrieve_result()
     else:
-        pool = None
-        apply_func = apply
+        pool = Pool(processes=1)
+        apply_func = pool.apply
         retrieve_func = retrieve_result_st()
 
     # Exhaustive generators.

--- a/nn_dataflow/core/loop_blocking_scheme.py
+++ b/nn_dataflow/core/loop_blocking_scheme.py
@@ -574,7 +574,7 @@ class LoopBlockingScheme(object):
         gens = [None] * le.NUM
         rev_order = [le.NUM - 1 - o for o in order_x]
         for lpe in range(le.NUM):
-            gens[rev_order[lpe]] = xrange(t_x[lpe])
+            gens[rev_order[lpe]] = range(t_x[lpe])
 
         for idx in itertools.product(*gens):
             # Index now is in the loop order from outer to inner. Reorder to be

--- a/nn_dataflow/core/loop_blocking_scheme.py
+++ b/nn_dataflow/core/loop_blocking_scheme.py
@@ -134,8 +134,7 @@ class LoopBlockingScheme():
                 or self.data_size(BL.GBUF) > resource.size_gbuf:
             self.valid = False
             return
-        else:
-            self.valid = True
+        self.valid = True
 
         # Data fetch calculation.
         self._set_fetch()

--- a/nn_dataflow/core/loop_blocking_scheme.py
+++ b/nn_dataflow/core/loop_blocking_scheme.py
@@ -91,7 +91,8 @@ class LoopBlockingScheme(object):
                 'LoopBlockingScheme: bl_ts elements have invalid length.'
         assert len(bl_ords) == BL.NUM, \
                 'LoopBlockingScheme: bl_ords has invalid length.'
-        assert all(sorted(bl_ord) == range(le.NUM) for bl_ord in bl_ords), \
+        assert all(tuple(sorted(bl_ord)) == tuple(range(le.NUM)) \
+                   for bl_ord in bl_ords), \
                 'LoopBlockingScheme: bl_ords elements are invalid.'
 
         self.bl_ts = [tuple(bl_t) for bl_t in bl_ts]

--- a/nn_dataflow/core/loop_blocking_scheme.py
+++ b/nn_dataflow/core/loop_blocking_scheme.py
@@ -143,13 +143,7 @@ class LoopBlockingScheme(object):
         self.src_is_dram = (resource.src_data_region.type == NodeRegion.DRAM)
         self.dst_is_dram = (resource.dst_data_region.type == NodeRegion.DRAM)
 
-        # Check resource for filter pinning.
         self.filter_pinned = False
-        if resource.no_time_mux:
-            if all(self.bl_ts[0][lpe] == 1 for lpe
-                   in self.nld.data_loops[de.FIL].loops()):
-                self.filter_pinned = True
-                self.fetch[0][de.FIL] = 0
 
         # If data regions are not DRAM, can only access once, no spilling.
         if not self.src_is_dram:
@@ -214,6 +208,13 @@ class LoopBlockingScheme(object):
 
         # Remote gbuf access.
         self.remote_gbuf_access = [0.] * de.NUM
+
+        # Check resource for filter pinning.
+        if resource.no_time_mux:
+            if all(self.bl_ts[0][lpe] == 1 for lpe
+                   in self.nld.data_loops[de.FIL].loops()):
+                self.filter_pinned = True
+                self.fetch[0][de.FIL] = 0
 
     def is_valid(self):
         '''

--- a/nn_dataflow/core/loop_blocking_scheme.py
+++ b/nn_dataflow/core/loop_blocking_scheme.py
@@ -22,7 +22,7 @@ from . import mem_hier_enum as me
 from .node_region import NodeRegion
 from .. import util
 
-class LoopBlockingScheme(object):
+class LoopBlockingScheme():
     '''
     Loop blocking scheme.
 
@@ -30,7 +30,7 @@ class LoopBlockingScheme(object):
     '''
     # pylint: disable=too-many-instance-attributes
 
-    class BL(object):  # pylint: disable=too-few-public-methods
+    class BL():  # pylint: disable=too-few-public-methods
         '''
         Blocking-level enum. Only used locally.
         '''

--- a/nn_dataflow/core/map_strategy.py
+++ b/nn_dataflow/core/map_strategy.py
@@ -21,7 +21,7 @@ from .layer import Layer, ConvLayer, LocalRegionLayer
 from .nested_loop_desc import NestedLoopDesc
 from .phy_dim2 import PhyDim2
 
-class MapStrategy(object):
+class MapStrategy():
     '''
     Base mapping strategy.
 

--- a/nn_dataflow/core/network.py
+++ b/nn_dataflow/core/network.py
@@ -17,7 +17,7 @@ from collections import OrderedDict
 
 from .layer import Layer, InputLayer
 
-class Network(object):
+class Network():
     '''
     NN topology. Support DAG structure of layers.
     '''

--- a/nn_dataflow/core/network.py
+++ b/nn_dataflow/core/network.py
@@ -83,7 +83,7 @@ class Network(object):
                                    'has not been added to the network'.
                                    format(p))
         else:
-            prevs = (self.layer_dict.keys()[-1],)
+            prevs = (list(self.layer_dict.keys())[-1],)
 
         self.layer_dict[layer_name] = layer
         self.prevs_dict[layer_name] = prevs

--- a/nn_dataflow/core/nn_dataflow.py
+++ b/nn_dataflow/core/nn_dataflow.py
@@ -212,10 +212,12 @@ class NNDataflow(object):
                 # Temporal scheduling.
                 for tm_idx, (layer, resource, cstr) \
                         in enumerate(zip(ltpl, rtpl, ctpl)):
+
                     curr_nndf_tops = self._layer_schedule_search(
                         layer, resource, cstr, sp_idx, tm_idx,
                         fwd_data_region_dict.get((sp_idx, tm_idx)),
                         curr_nndf_tops, options)
+
             # Filter by time limit.
             seg_nndf_tops = [nndf for nndf in curr_nndf_tops
                              if all(timing.time_overhead <= max_time_ovhd

--- a/nn_dataflow/core/nn_dataflow.py
+++ b/nn_dataflow/core/nn_dataflow.py
@@ -14,7 +14,6 @@ program. If not, see <https://opensource.org/licenses/BSD-3-Clause>.
 """
 
 from collections import defaultdict
-import itertools
 import sys
 
 from . import partition

--- a/nn_dataflow/core/nn_dataflow.py
+++ b/nn_dataflow/core/nn_dataflow.py
@@ -325,23 +325,12 @@ class NNDataflow(object):
                 regions=(input_region,),
                 parts=(part.projection(input_region, appl2frng=True),))
 
-            if ext_layers:
-                for ext_parts in itertools.product(
-                        *[partition.gen_partition(ext_layer, self.batch_size,
-                                                  ext_region.dim, options,
-                                                  guaranteed=True)
-                          for ext_layer in ext_layers]):
-                    ext_layout_dict = dict(zip(
-                        ext_layer_names,
-                        [DataLayout(
-                            frngs=(ext_frng,),
-                            regions=(ext_region,),
-                            parts=(ext_part.projection(ext_region,
-                                                       appl2frng=True),))
-                         for ext_part, ext_frng in zip(ext_parts, ext_frngs)]))
+            ext_layout_dict = dict(zip(
+                ext_layer_names,
+                [DataLayout(
+                    frngs=(ext_frng,),
+                    regions=(ext_region,),
+                    parts=(part.projection(ext_region, appl2frng=True),))
+                 for ext_frng in ext_frngs])) if ext_layers else None
 
-                    yield input_layout, ext_layout_dict
-
-            else:
-                yield input_layout, None
-
+            yield input_layout, ext_layout_dict

--- a/nn_dataflow/core/nn_dataflow.py
+++ b/nn_dataflow/core/nn_dataflow.py
@@ -212,12 +212,10 @@ class NNDataflow(object):
                 # Temporal scheduling.
                 for tm_idx, (layer, resource, cstr) \
                         in enumerate(zip(ltpl, rtpl, ctpl)):
-
                     curr_nndf_tops = self._layer_schedule_search(
                         layer, resource, cstr, sp_idx, tm_idx,
                         fwd_data_region_dict.get((sp_idx, tm_idx)),
                         curr_nndf_tops, options)
-
             # Filter by time limit.
             seg_nndf_tops = [nndf for nndf in curr_nndf_tops
                              if all(timing.time_overhead <= max_time_ovhd

--- a/nn_dataflow/core/nn_dataflow.py
+++ b/nn_dataflow/core/nn_dataflow.py
@@ -28,7 +28,7 @@ from .nn_dataflow_scheme import NNDataflowScheme
 from .resource import Resource
 from .scheduling import SchedulingCondition, Scheduling
 
-class NNDataflow(object):
+class NNDataflow():
     '''
     Search optimized dataflows for neural networks.
     '''

--- a/nn_dataflow/core/nn_dataflow_scheme.py
+++ b/nn_dataflow/core/nn_dataflow_scheme.py
@@ -13,7 +13,8 @@ You should have received a copy of the Modified BSD-3 License along with this
 program. If not, see <https://opensource.org/licenses/BSD-3-Clause>.
 """
 
-from collections import OrderedDict, MutableMapping
+from collections import OrderedDict
+from collections.abc import MutableMapping
 
 from . import mem_hier_enum as me
 from .. import util

--- a/nn_dataflow/core/partition.py
+++ b/nn_dataflow/core/partition.py
@@ -325,7 +325,7 @@ def _unit_nhops_to_fil(layer, filter_nodes, fil_dict, fwd=False):
                 # Each forward step, get the min-distance pair of source and
                 # destination.
                 src, dst = min(itertools.product(src_set, dst_set),
-                               key=lambda (s, d): d.hop_dist(s))
+                               key=lambda sd: sd[1].hop_dist(sd[0]))
                 dst_set.remove(dst)
                 src_set.add(dst)
                 nhops += fil_size * dst.hop_dist(src)

--- a/nn_dataflow/core/partition.py
+++ b/nn_dataflow/core/partition.py
@@ -53,7 +53,7 @@ def gen_partition(layer, batch_size, dim_nodes, options, guaranteed=False):
         # Batch partitoning.
         if (not options.partition_batch) and pdims[pe.BATP].size() > 1:
             continue
-        elif batch_size % pdims[pe.BATP].size() != 0:
+        if batch_size % pdims[pe.BATP].size() != 0:
             continue
 
         # Force each partitioning to fully utilize one dimension before
@@ -72,14 +72,13 @@ def gen_partition(layer, batch_size, dim_nodes, options, guaranteed=False):
 
             if (not options.partition_ifmaps) and pdims[pe.INPP].size() > 1:
                 continue
-            else:
-                if isinstance(layer, ConvLayer):
-                    if not util.approx_dividable(layer.nifm,
-                                                 pdims[pe.INPP].size()):
-                        continue
-                elif isinstance(layer, LocalRegionLayer):
-                    if pdims[pe.INPP].size() > 1:
-                        continue
+            if isinstance(layer, ConvLayer):
+                if not util.approx_dividable(layer.nifm,
+                                             pdims[pe.INPP].size()):
+                    continue
+            elif isinstance(layer, LocalRegionLayer):
+                if pdims[pe.INPP].size() > 1:
+                    continue
         else:
             assert not options.partition_ifmaps
             if pdims[pe.INPP].size() != 1:

--- a/nn_dataflow/core/phy_dim2.py
+++ b/nn_dataflow/core/phy_dim2.py
@@ -14,6 +14,7 @@ program. If not, see <https://opensource.org/licenses/BSD-3-Clause>.
 """
 
 from collections import namedtuple
+from functools import reduce
 from operator import add, sub, neg, mul
 
 class PhyDim2(namedtuple('PhyDim2', ['h', 'w'])):

--- a/nn_dataflow/core/pipeline_segment.py
+++ b/nn_dataflow/core/pipeline_segment.py
@@ -124,7 +124,9 @@ class PipelineSegment(object):
         for valp in itertools.product(*vals):
 
             constraint = tuple()
-            for atpl in self._subs_symargs(self.cstr_symargs, tuple(zip(syms, valp))):
+
+            for atpl in self._subs_symargs(self.cstr_symargs,
+                                           tuple(zip(syms, valp))):
                 ctpl = tuple()
                 for a in atpl:
                     # Construct kwargs, adjust the types of the values.

--- a/nn_dataflow/core/pipeline_segment.py
+++ b/nn_dataflow/core/pipeline_segment.py
@@ -112,6 +112,7 @@ class PipelineSegment(object):
         # hint A are larger than the corresponding values in hint B, A will be
         # generated after B.
         vals = [sorted(v) for v in vals]
+        syms = list(syms)
 
         if self.cstr_topbat_idx is not None:
             # Tovhd =  (1 + 1/to + 1 + 1/to + ...) / tb
@@ -123,8 +124,7 @@ class PipelineSegment(object):
         for valp in itertools.product(*vals):
 
             constraint = tuple()
-
-            for atpl in self._subs_symargs(self.cstr_symargs, zip(syms, valp)):
+            for atpl in self._subs_symargs(self.cstr_symargs, tuple(zip(syms, valp))):
                 ctpl = tuple()
                 for a in atpl:
                     # Construct kwargs, adjust the types of the values.

--- a/nn_dataflow/core/pipeline_segment.py
+++ b/nn_dataflow/core/pipeline_segment.py
@@ -907,6 +907,7 @@ class PipelineSegment():
 
     class TopOfmUpdateLambda(symbasic):
         ''' A sympifi-able lambda function to lazily update topofm. '''
+        # pylint: disable=no-init
         def __new__(cls, *args):
             return super(PipelineSegment.TopOfmUpdateLambda, cls).__new__(cls)
         def __call__(self, arg_s, arg_r):

--- a/nn_dataflow/core/pipeline_segment.py
+++ b/nn_dataflow/core/pipeline_segment.py
@@ -28,7 +28,7 @@ from .network import Network
 from .resource import Resource
 from .scheduling_constraint import SchedulingConstraintLayerPipeline as Cstr
 
-class PipelineSegment(object):
+class PipelineSegment():
     '''
     Inter-layer pipeline segment.
 

--- a/nn_dataflow/core/pipeline_segment_timing.py
+++ b/nn_dataflow/core/pipeline_segment_timing.py
@@ -20,7 +20,7 @@ from .loop_blocking_scheme import LoopBlockingScheme
 from .layer import ConvLayer
 from .network import Network
 
-class PipelineSegmentTiming(object):
+class PipelineSegmentTiming():
     ''' Timing information of a pipeline segment. '''
 
     # Each layer timing info is a tuple:

--- a/nn_dataflow/core/pipeline_segment_timing.py
+++ b/nn_dataflow/core/pipeline_segment_timing.py
@@ -171,7 +171,7 @@ class PipelineSegmentTiming():
             top_ts[le.BAT] = ord_loops.pop(0)[1]
         if ord_loops:
             lpe, t = ord_loops.pop(0)
-            assert lpe == le.IFM or lpe == le.OFM
+            assert lpe in (le.IFM, le.OFM)
             top_ts[lpe] = t
 
         # Lazily update BAT group number.

--- a/nn_dataflow/core/scheduling.py
+++ b/nn_dataflow/core/scheduling.py
@@ -225,7 +225,6 @@ class Scheduling(object):
             tops += [self._get_result(lbs, part, ofmap_layout,
                                       condition.sched_seq, unit_nhops)
                      for lbs in lbs_tops]
-
         # Pick the top n.
         tops = sorted(tops, key=self.cmp_key)[:options.ntops]
 
@@ -271,12 +270,10 @@ class Scheduling(object):
 
         # Explore PE array mapping schemes for partitioned layer.
         for nested_loop_desc in map_strategy.gen_nested_loop_desc():
-
             # Explore loop blocking schemes.
             for lbs in loop_blocking.gen_loopblocking(
                     nested_loop_desc, resource, part, constraint, self.cost,
                     options):
-
                 if lbs.is_valid():
                     lbs_tops.append(lbs)
 

--- a/nn_dataflow/core/scheduling.py
+++ b/nn_dataflow/core/scheduling.py
@@ -325,7 +325,7 @@ class Scheduling(object):
         scheme['fetch'] = lbs.fetch
 
         # Loop blocking.
-        lp_ts = zip(*lbs.bl_ts)
+        lp_ts = list(zip(*lbs.bl_ts))
         scheme['ti'] = tuple(lp_ts[le.IFM])
         scheme['to'] = tuple(lp_ts[le.OFM])
         scheme['tb'] = tuple(lp_ts[le.BAT])

--- a/nn_dataflow/core/scheduling.py
+++ b/nn_dataflow/core/scheduling.py
@@ -136,7 +136,7 @@ class SchedulingResult(namedtuple('SchedulingResult',
         return self.scheme['num_nodes']
 
 
-class Scheduling(object):
+class Scheduling():
     '''
     Layer scheduling.
     '''

--- a/nn_dataflow/core/scheduling.py
+++ b/nn_dataflow/core/scheduling.py
@@ -225,6 +225,7 @@ class Scheduling(object):
             tops += [self._get_result(lbs, part, ofmap_layout,
                                       condition.sched_seq, unit_nhops)
                      for lbs in lbs_tops]
+
         # Pick the top n.
         tops = sorted(tops, key=self.cmp_key)[:options.ntops]
 
@@ -270,10 +271,12 @@ class Scheduling(object):
 
         # Explore PE array mapping schemes for partitioned layer.
         for nested_loop_desc in map_strategy.gen_nested_loop_desc():
+
             # Explore loop blocking schemes.
             for lbs in loop_blocking.gen_loopblocking(
                     nested_loop_desc, resource, part, constraint, self.cost,
                     options):
+
                 if lbs.is_valid():
                     lbs_tops.append(lbs)
 

--- a/nn_dataflow/core/scheduling_constraint.py
+++ b/nn_dataflow/core/scheduling_constraint.py
@@ -106,7 +106,7 @@ class SchedulingConstraint(util.ContentHashClass):
     def _filter_gen(gen, topt=0):
         ''' Get a new generator which filters the top factor. '''
         for tpl in gen:
-            if topt == 0 or tpl[0] == topt:
+            if topt in (0, tpl[0]):
                 yield tpl
 
     def __repr__(self):
@@ -143,14 +143,14 @@ class SchedulingConstraintLayerPipeline(SchedulingConstraint):
 
         if fbifm:
             # Fully-buffered IFM <=> topifm = 1.
-            if topifm != 0 and topifm != 1:
+            if topifm not in (0, 1):
                 raise ValueError('SchedulingConstraintLayerPipeline: '
                                  'fully-buffered IFM implies topifm = 1.')
             topifm = 1
 
         if fbofm:
             # Fully-buffered OFM <=> topofm = 1.
-            if topofm != 0 and topofm != 1:
+            if topofm not in (0, 1):
                 raise ValueError('SchedulingConstraintLayerPipeline: '
                                  'fully-buffered OFM implies topofm = 1.')
             topofm = 1

--- a/nn_dataflow/nns/resnet50.py
+++ b/nn_dataflow/nns/resnet50.py
@@ -1,0 +1,95 @@
+""" $lic$
+Copyright (C) 2016-2019 by The Board of Trustees of Stanford University
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the Modified BSD-3 License as published by the Open Source
+Initiative.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the BSD-3 License for more details.
+
+You should have received a copy of the Modified BSD-3 License along with this
+program. If not, see <https://opensource.org/licenses/BSD-3-Clause>.
+"""
+
+from nn_dataflow.core import Network
+from nn_dataflow.core import InputLayer, ConvLayer, FCLayer, \
+        PoolingLayer, EltwiseLayer
+
+'''
+ResNet-50
+
+He, Zhang, Ren, and Sun, 2015
+'''
+
+NN = Network('ResNet')
+
+NN.set_input_layer(InputLayer(3, 224))
+
+NN.add('conv1', ConvLayer(3, 64, 112, 7, 2))
+NN.add('pool1', PoolingLayer(64, 56, 3, 2))
+
+RES_PREV = 'pool1'
+
+for i in range(3):
+    NN.add('conv2_{}_a'.format(i), ConvLayer(64 if i == 0 else 256, 64, 56, 1))
+    NN.add('conv2_{}_b'.format(i), ConvLayer(64, 64, 56, 3))
+    NN.add('conv2_{}_c'.format(i), ConvLayer(64, 256, 56, 1))
+
+    # With residual shortcut.
+    if i == 0:
+        NN.add('conv2_br', ConvLayer(64, 256, 56, 1), prevs=(RES_PREV,))
+        RES_PREV = 'conv2_br'
+    NN.add('conv2_{}_res'.format(i), EltwiseLayer(256, 56, 2),
+           prevs=(RES_PREV, 'conv2_{}_c'.format(i)))
+    RES_PREV = 'conv2_{}_res'.format(i)
+
+for i in range(4):
+    NN.add('conv3_{}_a'.format(i),
+           ConvLayer(256, 128, 28, 1, 2) if i == 0
+           else ConvLayer(512, 128, 28, 1))
+    NN.add('conv3_{}_b'.format(i), ConvLayer(128, 128, 28, 3))
+    NN.add('conv3_{}_c'.format(i), ConvLayer(128, 512, 28, 1))
+
+    # With residual shortcut.
+    if i == 0:
+        NN.add('conv3_br', ConvLayer(256, 512, 28, 1, 2), prevs=(RES_PREV,))
+        RES_PREV = 'conv3_br'
+    NN.add('conv3_{}_res'.format(i), EltwiseLayer(512, 28, 2),
+           prevs=(RES_PREV, 'conv3_{}_c'.format(i)))
+    RES_PREV = 'conv3_{}_res'.format(i)
+
+for i in range(6):
+    NN.add('conv4_{}_a'.format(i),
+           ConvLayer(512, 256, 14, 1, 2) if i == 0
+           else ConvLayer(1024, 256, 14, 1))
+    NN.add('conv4_{}_b'.format(i), ConvLayer(256, 256, 14, 3))
+    NN.add('conv4_{}_c'.format(i), ConvLayer(256, 1024, 14, 1))
+
+    # With residual shortcut.
+    if i == 0:
+        NN.add('conv4_br', ConvLayer(512, 1024, 14, 1, 2), prevs=(RES_PREV,))
+        RES_PREV = 'conv4_br'
+    NN.add('conv4_{}_res'.format(i), EltwiseLayer(1024, 14, 2),
+           prevs=(RES_PREV, 'conv4_{}_c'.format(i)))
+    RES_PREV = 'conv4_{}_res'.format(i)
+
+for i in range(3):
+    NN.add('conv5_{}_a'.format(i),
+           ConvLayer(1024, 512, 7, 1, 2) if i == 0
+           else ConvLayer(2048, 512, 7, 1))
+    NN.add('conv5_{}_b'.format(i), ConvLayer(512, 512, 7, 3))
+    NN.add('conv5_{}_c'.format(i), ConvLayer(512, 2048, 7, 1))
+
+    # With residual shortcut.
+    if i == 0:
+        NN.add('conv5_br', ConvLayer(1024, 2048, 7, 1, 2), prevs=(RES_PREV,))
+        RES_PREV = 'conv5_br'
+    NN.add('conv5_{}_res'.format(i), EltwiseLayer(2048, 7, 2),
+           prevs=(RES_PREV, 'conv5_{}_c'.format(i)))
+    RES_PREV = 'conv5_{}_res'.format(i)
+
+NN.add('pool5', PoolingLayer(2048, 1, 7))
+
+NN.add('fc', FCLayer(2048, 1000))

--- a/nn_dataflow/tests/dataflow_test/test_nn_dataflow.py
+++ b/nn_dataflow/tests/dataflow_test/test_nn_dataflow.py
@@ -109,7 +109,7 @@ class TestNNDataflow(unittest.TestCase):
 
     def test_invalid_map_strategy(self):
         ''' Invalid map_strategy argument. '''
-        class _DummyClass(object):  # pylint: disable=too-few-public-methods
+        class _DummyClass():  # pylint: disable=too-few-public-methods
             pass
 
         with self.assertRaisesRegex(TypeError, 'NNDataflow: .*map_strategy.*'):

--- a/nn_dataflow/tests/dataflow_test/test_nn_dataflow.py
+++ b/nn_dataflow/tests/dataflow_test/test_nn_dataflow.py
@@ -15,7 +15,8 @@ program. If not, see <https://opensource.org/licenses/BSD-3-Clause>.
 
 import unittest
 import sys
-import StringIO
+
+from io import StringIO
 
 from nn_dataflow.core import Cost
 from nn_dataflow.core import InputLayer, ConvLayer, FCLayer
@@ -88,20 +89,20 @@ class TestNNDataflow(unittest.TestCase):
 
     def test_invalid_network(self):
         ''' Invalid network argument. '''
-        with self.assertRaisesRegexp(TypeError, 'NNDataflow: .*network.*'):
+        with self.assertRaisesRegex(TypeError, 'NNDataflow: .*network.*'):
             _ = NNDataflow(self.alex_net.input_layer(), 4,
                            self.resource, self.cost, self.map_strategy)
 
     def test_invalid_resource(self):
         ''' Invalid network argument. '''
-        with self.assertRaisesRegexp(TypeError, 'NNDataflow: .*resource.*'):
+        with self.assertRaisesRegex(TypeError, 'NNDataflow: .*resource.*'):
             _ = NNDataflow(self.alex_net, 4,
                            self.resource.proc_region, self.cost,
                            self.map_strategy)
 
     def test_invalid_cost(self):
         ''' Invalid network argument. '''
-        with self.assertRaisesRegexp(TypeError, 'NNDataflow: .*cost.*'):
+        with self.assertRaisesRegex(TypeError, 'NNDataflow: .*cost.*'):
             _ = NNDataflow(self.alex_net, 4,
                            self.resource, self.cost._asdict(),
                            self.map_strategy)
@@ -111,7 +112,7 @@ class TestNNDataflow(unittest.TestCase):
         class _DummyClass(object):  # pylint: disable=too-few-public-methods
             pass
 
-        with self.assertRaisesRegexp(TypeError, 'NNDataflow: .*map_strategy.*'):
+        with self.assertRaisesRegex(TypeError, 'NNDataflow: .*map_strategy.*'):
             _ = NNDataflow(self.alex_net, 4,
                            self.resource, self.cost, _DummyClass)
 
@@ -130,8 +131,8 @@ class TestNNDataflow(unittest.TestCase):
 
         old_stdout = sys.stdout
         old_stderr = sys.stderr
-        sys.stdout = stdout = StringIO.StringIO()
-        sys.stderr = stderr = StringIO.StringIO()
+        sys.stdout = stdout = StringIO()
+        sys.stderr = stderr = StringIO()
 
         tops, _ = nnd.schedule_search(options)
 
@@ -408,8 +409,8 @@ class TestNNDataflow(unittest.TestCase):
 
         old_stdout = sys.stdout
         old_stderr = sys.stderr
-        sys.stdout = stdout = StringIO.StringIO()
-        sys.stderr = stderr = StringIO.StringIO()
+        sys.stdout = stdout = StringIO()
+        sys.stderr = stderr = StringIO()
 
         with self.assertRaises(NotImplementedError):
             _ = nnd.schedule_search(self.options)

--- a/nn_dataflow/tests/dataflow_test/test_scheduling.py
+++ b/nn_dataflow/tests/dataflow_test/test_scheduling.py
@@ -93,13 +93,13 @@ class TestScheduling(unittest.TestCase):
 
     def test_invalid_layer(self):
         ''' Invalid layer argument. '''
-        with self.assertRaisesRegexp(TypeError, 'Scheduling: .*layer.*'):
+        with self.assertRaisesRegex(TypeError, 'Scheduling: .*layer.*'):
             _ = Scheduling((64, 128, 28, 3), self.batch_size, self.cost,
                            MapStrategyEyeriss)
 
     def test_invalid_cost(self):
         ''' Invalid cost argument. '''
-        with self.assertRaisesRegexp(TypeError, 'Scheduling: .*cost.*'):
+        with self.assertRaisesRegex(TypeError, 'Scheduling: .*cost.*'):
             _ = Scheduling(self.layers['BASE'], self.batch_size,
                            tuple(self.cost), MapStrategyEyeriss)
 
@@ -108,7 +108,7 @@ class TestScheduling(unittest.TestCase):
         class _DummyClass(object):  # pylint: disable=too-few-public-methods
             pass
 
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'Scheduling: .*map_strategy_class.*'):
             _ = Scheduling(self.layers['BASE'], self.batch_size, self.cost,
                            _DummyClass)
@@ -180,7 +180,7 @@ class TestScheduling(unittest.TestCase):
                               for r in self.ifmap_layouts['BASE'].regions)),
             sched_seq=self.sched_seq)
 
-        with self.assertRaisesRegexp(ValueError, 'Scheduling: .*ifmap.*'):
+        with self.assertRaisesRegex(ValueError, 'Scheduling: .*ifmap.*'):
             _ = schd.schedule_search(condition, self.options)
 
         # Not match layer.
@@ -190,7 +190,7 @@ class TestScheduling(unittest.TestCase):
             ifmap_layout=self.ifmap_layouts['POOL'],
             sched_seq=self.sched_seq)
 
-        with self.assertRaisesRegexp(ValueError, 'Scheduling: .*ifmap.*'):
+        with self.assertRaisesRegex(ValueError, 'Scheduling: .*ifmap.*'):
             _ = schd.schedule_search(condition, self.options)
 
     def test_schedule_search_nolbs(self):

--- a/nn_dataflow/tests/dataflow_test/test_scheduling.py
+++ b/nn_dataflow/tests/dataflow_test/test_scheduling.py
@@ -105,7 +105,7 @@ class TestScheduling(unittest.TestCase):
 
     def test_invalid_map_strategy(self):
         ''' Invalid cost argument. '''
-        class _DummyClass(object):  # pylint: disable=too-few-public-methods
+        class _DummyClass():  # pylint: disable=too-few-public-methods
             pass
 
         with self.assertRaisesRegex(TypeError,

--- a/nn_dataflow/tests/dataflow_test/test_scheduling.py
+++ b/nn_dataflow/tests/dataflow_test/test_scheduling.py
@@ -109,7 +109,7 @@ class TestScheduling(unittest.TestCase):
             pass
 
         with self.assertRaisesRegex(TypeError,
-                                     'Scheduling: .*map_strategy_class.*'):
+                                    'Scheduling: .*map_strategy_class.*'):
             _ = Scheduling(self.layers['BASE'], self.batch_size, self.cost,
                            _DummyClass)
 

--- a/nn_dataflow/tests/loop_blocking_test/test_loop_blocking_fixture.py
+++ b/nn_dataflow/tests/loop_blocking_test/test_loop_blocking_fixture.py
@@ -953,7 +953,7 @@ class TestLoopBlockingFixture(unittest.TestCase):
 
         outer_level_innermost_loop = None
 
-        for t_, ord_ in itertools.izip_longest(bl_ts, bl_ords, fillvalue=None):
+        for t_, ord_ in itertools.zip_longest(bl_ts, bl_ords, fillvalue=None):
 
             # Non-trivial loops and trivial loops of this level.
             ntlp_list = sorted(lpe for lpe in range(le.NUM)

--- a/nn_dataflow/tests/loop_blocking_test/test_loop_blocking_fixture.py
+++ b/nn_dataflow/tests/loop_blocking_test/test_loop_blocking_fixture.py
@@ -478,12 +478,11 @@ class TestLoopBlockingFixture(unittest.TestCase):
                         cur_buf_cap -= rem_frac
                         rem_frac = 0.
                         break
-                    else:
-                        # Partially fits.
-                        centroid += cur_buf_idx * cur_buf_cap
-                        rem_frac -= cur_buf_cap
-                        cur_buf_cap = self.buf_subrng_num
-                        cur_buf_idx += 1
+                    # Partially fits.
+                    centroid += cur_buf_idx * cur_buf_cap
+                    rem_frac -= cur_buf_cap
+                    cur_buf_cap = self.buf_subrng_num
+                    cur_buf_idx += 1
                 self.buf_subrng_centroid.append(centroid)
 
             # Rotation unit.
@@ -815,17 +814,16 @@ class TestLoopBlockingFixture(unittest.TestCase):
             return dram_access, gbuf_access, \
                     (rotation_access, wide_fetch_access, rotation_rounds)
 
-        else:
-            for dce in range(de.NUM):
-                self.assertAlmostEqual(gbufs[dce].rotation_access_size(), 0,
-                                       msg='_sim_access_conv: non-0 '
-                                           'rotation access with no bufshr.')
-                self.assertAlmostEqual(gbufs[dce].wide_fetch_access_size(), 0,
-                                       msg='_sim_access_conv: non-0 '
-                                           'wide fetch access with no bufshr.')
-                self.assertEqual(gbufs[dce].rotation_rounds(), 0,
-                                 msg='_sim_access_conv: non-0 '
-                                     'rotation rounds with no bufshr.')
+        for dce in range(de.NUM):
+            self.assertAlmostEqual(gbufs[dce].rotation_access_size(), 0,
+                                   msg='_sim_access_conv: non-0 '
+                                       'rotation access with no bufshr.')
+            self.assertAlmostEqual(gbufs[dce].wide_fetch_access_size(), 0,
+                                   msg='_sim_access_conv: non-0 '
+                                       'wide fetch access with no bufshr.')
+            self.assertEqual(gbufs[dce].rotation_rounds(), 0,
+                             msg='_sim_access_conv: non-0 '
+                                 'rotation rounds with no bufshr.')
 
         return dram_access, gbuf_access
 

--- a/nn_dataflow/tests/loop_blocking_test/test_loop_blocking_fixture.py
+++ b/nn_dataflow/tests/loop_blocking_test/test_loop_blocking_fixture.py
@@ -346,7 +346,7 @@ class TestLoopBlockingFixture(unittest.TestCase):
                             for lpe in range(le.NUM) if t_bs[lpe] > 1],
                            key=lambda tpl: ord_bs[tpl[0]],
                            reverse=True) \
-                  + sorted([(lpe, t_x[lpe] / t_bs[lpe])
+                  + sorted([(lpe, t_x[lpe] // t_bs[lpe])
                             for lpe in range(le.NUM) if t_x[lpe] > t_bs[lpe]],
                            key=lambda tpl: ord_x[tpl[0]],
                            reverse=True)
@@ -517,7 +517,7 @@ class TestLoopBlockingFixture(unittest.TestCase):
             ''' Get number of rotation rounds. '''
 
             # Ensure all ranges have the same rotation steps.
-            steps_list = self.rot_step_cnt.values()
+            steps_list = tuple(self.rot_step_cnt.values())
             if not steps_list:
                 return 0
             assert all(s == steps_list[0] for s in steps_list)
@@ -719,7 +719,7 @@ class TestLoopBlockingFixture(unittest.TestCase):
 
         data_loops = lbs.nld.data_loops
 
-        lpts = zip(*lbs.bl_ts)
+        lpts = tuple(zip(*lbs.bl_ts))
 
         subgrp_size, rot_unit_cnt, lp_t_list = self._bufshr_params(lbs)
         data_loops = lbs.nld.data_loops

--- a/nn_dataflow/tests/loop_blocking_test/test_loop_blocking_fixture.py
+++ b/nn_dataflow/tests/loop_blocking_test/test_loop_blocking_fixture.py
@@ -354,7 +354,7 @@ class TestLoopBlockingFixture(unittest.TestCase):
         return subgrp_size, rot_unit_cnt, lp_t_list
 
 
-    class _SimBuffer(object):
+    class _SimBuffer():
         ''' A data buffer model for simulation. '''
 
         def __init__(self, dce, buf_cnt_pr, unit_size, bypass=False):

--- a/nn_dataflow/tests/loop_blocking_test/test_loop_blocking_solver.py
+++ b/nn_dataflow/tests/loop_blocking_test/test_loop_blocking_solver.py
@@ -116,7 +116,7 @@ class TestLoopBlockingSolver(TestLoopBlockingFixture):
                         'test_reside_sol_opt: wlkey {} rsrckey {}: '
                         'solutions do not cover all optimal ones. '
                         'sol {} opt {}.'
-                        .format(wlkey, rsrckey, sol_sch_dict, min_sch_dict))                       
+                        .format(wlkey, rsrckey, sol_sch_dict, min_sch_dict))
 
         self.assertListEqual(
             min(sol_sch_dict.values()), min(min_sch_dict.values()),

--- a/nn_dataflow/tests/loop_blocking_test/test_loop_blocking_solver.py
+++ b/nn_dataflow/tests/loop_blocking_test/test_loop_blocking_solver.py
@@ -112,11 +112,11 @@ class TestLoopBlockingSolver(TestLoopBlockingFixture):
                 if not sol_sch or _cost(lbs) < sol_sch:
                     sol_sch_dict[true_reside_dce] = _cost(lbs)
 
-        self.assertDictContainsSubset(
-            sol_sch_dict, min_sch_dict,
-            'test_reside_sol_opt: wlkey {} rsrckey {}: '
-            'solutions do not cover all optimal ones. sol {} opt {}.'
-            .format(wlkey, rsrckey, sol_sch_dict, min_sch_dict))
+        self.assertTrue(sol_sch_dict.items() <= min_sch_dict.items(),
+                        'test_reside_sol_opt: wlkey {} rsrckey {}: '
+                        'solutions do not cover all optimal ones. '
+                        'sol {} opt {}.'
+                        .format(wlkey, rsrckey, sol_sch_dict, min_sch_dict))                       
 
         self.assertListEqual(
             min(sol_sch_dict.values()), min(min_sch_dict.values()),
@@ -134,7 +134,7 @@ class TestLoopBlockingSolver(TestLoopBlockingFixture):
     def test_reside_sol_opt_pool(self):
         ''' Data reside solution optimal with PoolingLayer. '''
 
-        with self.assertRaisesRegexp(ValueError, 'loop_blocking_solver: .*'):
+        with self.assertRaisesRegex(ValueError, 'loop_blocking_solver: .*'):
             self.test_reside_sol_opt(wlkey='POOL')
 
     def test_reside_sol_opt_zero(self):

--- a/nn_dataflow/tests/map_strategy_test/test_map_strategy.py
+++ b/nn_dataflow/tests/map_strategy_test/test_map_strategy.py
@@ -37,28 +37,28 @@ class TestMapStrategy(TestMapStrategyFixture):
 
     def test_inv_args(self):
         ''' Constructor arguments invalid. '''
-        with self.assertRaisesRegexp(TypeError, 'MapStrategy: .*layer.*'):
+        with self.assertRaisesRegex(TypeError, 'MapStrategy: .*layer.*'):
             _ = MapStrategy(None, 4, 1, self.dim_array)
 
-        with self.assertRaisesRegexp(ValueError, 'MapStrategy: .*occupancy.*'):
+        with self.assertRaisesRegex(ValueError, 'MapStrategy: .*occupancy.*'):
             _ = MapStrategy(self.layer, 4, -.1, self.dim_array)
-        with self.assertRaisesRegexp(ValueError, 'MapStrategy: .*occupancy.*'):
+        with self.assertRaisesRegex(ValueError, 'MapStrategy: .*occupancy.*'):
             _ = MapStrategy(self.layer, 4, 1.1, self.dim_array)
 
-        with self.assertRaisesRegexp(TypeError, 'MapStrategy: .*dim_array.*'):
+        with self.assertRaisesRegex(TypeError, 'MapStrategy: .*dim_array.*'):
             _ = MapStrategy(self.layer, 4, 1, None)
 
     def test_utilization(self):
         ''' Accessor utilization. '''
         ms = MapStrategy(self.layer, 4, 1, self.dim_array)
 
-        with self.assertRaisesRegexp(NotImplementedError, 'MapStrategy: .*'):
+        with self.assertRaisesRegex(NotImplementedError, 'MapStrategy: .*'):
             _ = ms.utilization()
 
     def test_gen_nested_loop_desc(self):
         ''' Generator gen_nested_loop_desc. '''
         ms = MapStrategy(self.layer, 4, 1, self.dim_array)
 
-        with self.assertRaisesRegexp(NotImplementedError, 'MapStrategy: .*'):
+        with self.assertRaisesRegex(NotImplementedError, 'MapStrategy: .*'):
             _ = ms.gen_nested_loop_desc()
 

--- a/nn_dataflow/tests/map_strategy_test/test_map_strategy_eyeriss.py
+++ b/nn_dataflow/tests/map_strategy_test/test_map_strategy_eyeriss.py
@@ -34,7 +34,7 @@ class TestMapStrategyEyeriss(TestMapStrategyFixture):
 
     def test_invalid_layer(self):
         ''' Constructor with invalid layer type. '''
-        with self.assertRaisesRegexp(TypeError, 'MapEyeriss: .*type.*'):
+        with self.assertRaisesRegex(TypeError, 'MapEyeriss: .*type.*'):
             _ = MapStrategyEyeriss(Layer(1, 1), 4, 1, self.dim_array)
 
     def test_nested_loop_desc_sanity(self):
@@ -43,8 +43,10 @@ class TestMapStrategyEyeriss(TestMapStrategyFixture):
         batch_size = 4
         occ = 1
 
-        for layer in self.convlayers.values() + self.fclayers.values() \
-                + self.lrlayers.values() + self.fake_layers.values():
+        for layer in tuple(self.convlayers.values()) + \
+                     tuple(self.fclayers.values()) + \
+                     tuple(self.lrlayers.values()) + \
+                     tuple(self.fake_layers.values()):
 
             ms = MapStrategyEyeriss(layer, batch_size, occ, self.dim_array)
 
@@ -127,8 +129,10 @@ class TestMapStrategyEyeriss(TestMapStrategyFixture):
         occ0 = 1
         occ1 = 0.8
 
-        for layer in self.convlayers.values() + self.fclayers.values() \
-                + self.lrlayers.values() + self.fake_layers.values():
+        for layer in tuple(self.convlayers.values()) + \
+                     tuple(self.fclayers.values()) + \
+                     tuple(self.lrlayers.values()) + \
+                     tuple(self.fake_layers.values()):
 
             ms0 = MapStrategyEyeriss(layer, batch_size, occ0, self.dim_array)
             ms1 = MapStrategyEyeriss(layer, batch_size, occ1, self.dim_array)

--- a/nn_dataflow/tests/nns_test/test_nns.py
+++ b/nn_dataflow/tests/nns_test/test_nns.py
@@ -37,7 +37,7 @@ class TestNNs(unittest.TestCase):
 
     def test_import_network_invalid(self):
         ''' Get import_network invalid. '''
-        with self.assertRaisesRegexp(ImportError, 'nns: .*defined.*'):
+        with self.assertRaisesRegex(ImportError, 'nns: .*defined.*'):
             _ = nns.import_network('aaa')
 
     def test_add_lstm_cell(self):
@@ -61,7 +61,7 @@ class TestNNs(unittest.TestCase):
 
     def test_add_lstm_cell_invalid_type(self):
         ''' Add LSTM cell with invalid type. '''
-        with self.assertRaisesRegexp(TypeError, 'add_lstm_cell: .*network.*'):
+        with self.assertRaisesRegex(TypeError, 'add_lstm_cell: .*network.*'):
             _ = nns.add_lstm_cell(InputLayer(512, 1), 'cell0', 512,
                                   None, None, None)
 
@@ -69,21 +69,21 @@ class TestNNs(unittest.TestCase):
         ''' Add LSTM cell input not in. '''
         net = Network('LSTM')
         net.set_input_layer(InputLayer(512, 1))
-        with self.assertRaisesRegexp(ValueError, 'add_lstm_cell: .*in.*'):
+        with self.assertRaisesRegex(ValueError, 'add_lstm_cell: .*in.*'):
             _ = nns.add_lstm_cell(net, 'cell0', 512,
                                   'a', net.INPUT_LAYER_KEY,
                                   net.INPUT_LAYER_KEY)
 
         net = Network('LSTM')
         net.set_input_layer(InputLayer(512, 1))
-        with self.assertRaisesRegexp(ValueError, 'add_lstm_cell: .*in.*'):
+        with self.assertRaisesRegex(ValueError, 'add_lstm_cell: .*in.*'):
             _ = nns.add_lstm_cell(net, 'cell0', 512,
                                   net.INPUT_LAYER_KEY, 'a',
                                   net.INPUT_LAYER_KEY)
 
         net = Network('LSTM')
         net.set_input_layer(InputLayer(512, 1))
-        with self.assertRaisesRegexp(ValueError, 'add_lstm_cell: .*in.*'):
+        with self.assertRaisesRegex(ValueError, 'add_lstm_cell: .*in.*'):
             _ = nns.add_lstm_cell(net, 'cell0', 512,
                                   net.INPUT_LAYER_KEY, net.INPUT_LAYER_KEY,
                                   'a')

--- a/nn_dataflow/tests/partition_test/test_gen_partition.py
+++ b/nn_dataflow/tests/partition_test/test_gen_partition.py
@@ -203,7 +203,7 @@ class TestGenPartition(TestPartitionFixture):
 
         for wlkey in self.layers:
             if wlkey.startswith('SSM'):
-                print wlkey
+                print(wlkey)
                 self.assertEqual(len(list(self._gen_partition(wlkey=wlkey,
                                                               optkey=optkey))),
                                  0)

--- a/nn_dataflow/tests/pipeline_test/test_inter_layer_pipeline.py
+++ b/nn_dataflow/tests/pipeline_test/test_inter_layer_pipeline.py
@@ -39,26 +39,26 @@ class TestInterLayerPipeline(TestPipelineFixture):
     def test_invalid_network(self):
         ''' Invalid network. '''
         with self.assertRaisesRegex(TypeError,
-                                     'InterLayerPipeline: .*network.*'):
+                                    'InterLayerPipeline: .*network.*'):
             _ = InterLayerPipeline(self.net['net1'].input_layer(),
                                    self.batch_size, self.resource)
 
     def test_invalid_resource(self):
         ''' Invalid resource. '''
         with self.assertRaisesRegex(TypeError,
-                                     'InterLayerPipeline: .*resource.*'):
+                                    'InterLayerPipeline: .*resource.*'):
             _ = InterLayerPipeline(self.net['net1'], self.batch_size,
                                    PhyDim2(1, 1))
 
     def test_invalid_max_util_drop(self):
         ''' Invalid max_util_drop. '''
         with self.assertRaisesRegex(ValueError,
-                                     'InterLayerPipeline: .*max_util_drop.*'):
+                                    'InterLayerPipeline: .*max_util_drop.*'):
             _ = InterLayerPipeline(self.net['net1'], self.batch_size,
                                    self.resource, max_util_drop=1.1)
 
         with self.assertRaisesRegex(ValueError,
-                                     'InterLayerPipeline: .*max_util_drop.*'):
+                                    'InterLayerPipeline: .*max_util_drop.*'):
             _ = InterLayerPipeline(self.net['net1'], self.batch_size,
                                    self.resource, max_util_drop=-0.1)
 

--- a/nn_dataflow/tests/pipeline_test/test_inter_layer_pipeline.py
+++ b/nn_dataflow/tests/pipeline_test/test_inter_layer_pipeline.py
@@ -38,26 +38,26 @@ class TestInterLayerPipeline(TestPipelineFixture):
 
     def test_invalid_network(self):
         ''' Invalid network. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'InterLayerPipeline: .*network.*'):
             _ = InterLayerPipeline(self.net['net1'].input_layer(),
                                    self.batch_size, self.resource)
 
     def test_invalid_resource(self):
         ''' Invalid resource. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'InterLayerPipeline: .*resource.*'):
             _ = InterLayerPipeline(self.net['net1'], self.batch_size,
                                    PhyDim2(1, 1))
 
     def test_invalid_max_util_drop(self):
         ''' Invalid max_util_drop. '''
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'InterLayerPipeline: .*max_util_drop.*'):
             _ = InterLayerPipeline(self.net['net1'], self.batch_size,
                                    self.resource, max_util_drop=1.1)
 
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'InterLayerPipeline: .*max_util_drop.*'):
             _ = InterLayerPipeline(self.net['net1'], self.batch_size,
                                    self.resource, max_util_drop=-0.1)

--- a/nn_dataflow/tests/pipeline_test/test_pipeline_fixture.py
+++ b/nn_dataflow/tests/pipeline_test/test_pipeline_fixture.py
@@ -366,7 +366,7 @@ class TestPipelineFixture(unittest.TestCase):
 
         seg_layers = set(l for ltpl in segment for l in ltpl)
 
-        class OutAccPat(object):
+        class OutAccPat():
             ''' Output data access pattern types. '''
             # pylint: disable=too-few-public-methods
             ANY = 0   # can access in any way

--- a/nn_dataflow/tests/pipeline_test/test_pipeline_fixture.py
+++ b/nn_dataflow/tests/pipeline_test/test_pipeline_fixture.py
@@ -434,7 +434,8 @@ class TestPipelineFixture(unittest.TestCase):
                 seq = None
                 # str is greater than all numbers, see
                 # https://docs.python.org/2/library/stdtypes.html#comparisons
-                seq_prev_oaps = [poap for poap in prev_oaps if poap > 0]
+                seq_prev_oaps = [poap for poap in prev_oaps \
+                                 if isinstance(poap, str)]
                 if seq_prev_oaps:
                     self.assertEqual(len(seq_prev_oaps), 1,
                                      '_validate_constraint: layer {} ({}) '

--- a/nn_dataflow/tests/pipeline_test/test_pipeline_fixture.py
+++ b/nn_dataflow/tests/pipeline_test/test_pipeline_fixture.py
@@ -435,7 +435,8 @@ class TestPipelineFixture(unittest.TestCase):
                 # str is greater than all numbers, see
                 # https://docs.python.org/2/library/stdtypes.html#comparisons
                 seq_prev_oaps = [poap for poap in prev_oaps \
-                                 if isinstance(poap, str)]
+                                 if isinstance(poap, str) or \
+                                    (isinstance(poap, int) and poap > 0)]
                 if seq_prev_oaps:
                     self.assertEqual(len(seq_prev_oaps), 1,
                                      '_validate_constraint: layer {} ({}) '

--- a/nn_dataflow/tests/pipeline_test/test_pipeline_fixture.py
+++ b/nn_dataflow/tests/pipeline_test/test_pipeline_fixture.py
@@ -483,13 +483,12 @@ class TestPipelineFixture(unittest.TestCase):
                     if any(pl in ltpl for pl in prev_layers):
                         # Local source.
                         lcl_poap = avail_data[sp_idx][1]
-                        self.assertTrue(lcl_poap == OutAccPat.DBF
-                                        or lcl_poap == OutAccPat.ANY,
-                                        '_validate_constraint: layer {} ({}) '
-                                        'local source data {} must fully '
-                                        'buffer output.'
-                                        .format(layer, (sp_idx, tm_idx),
-                                                lcl_poap))
+                        self.assertIn(lcl_poap, (OutAccPat.DBF, OutAccPat.ANY),
+                                      '_validate_constraint: layer {} ({}) '
+                                      'local source data {} must fully '
+                                      'buffer output.'
+                                      .format(layer, (sp_idx, tm_idx),
+                                              lcl_poap))
 
                     # DBF source.
                     if OutAccPat.DBF in prev_oaps:

--- a/nn_dataflow/tests/pipeline_test/test_pipeline_segment.py
+++ b/nn_dataflow/tests/pipeline_test/test_pipeline_segment.py
@@ -42,13 +42,13 @@ class TestPipelineSegment(TestPipelineFixture):
     def test_invalid_seg(self):
         ''' Invalid seg. '''
         with self.assertRaisesRegex(TypeError,
-                                     'PipelineSegment: .*seg.*tuple.*'):
+                                    'PipelineSegment: .*seg.*tuple.*'):
             _ = PipelineSegment([('0',), ('1', '1p')],
                                 self.net['net1'], self.batch_size,
                                 self.resource)
 
         with self.assertRaisesRegex(TypeError,
-                                     'PipelineSegment: .*seg.*sub-tuple.*'):
+                                    'PipelineSegment: .*seg.*sub-tuple.*'):
             _ = PipelineSegment(('0', '1', '1p'),
                                 self.net['net1'], self.batch_size,
                                 self.resource)
@@ -56,7 +56,7 @@ class TestPipelineSegment(TestPipelineFixture):
     def test_invalid_network(self):
         ''' Invalid network. '''
         with self.assertRaisesRegex(TypeError,
-                                     'PipelineSegment: .*network.*'):
+                                    'PipelineSegment: .*network.*'):
             _ = PipelineSegment((('0',), ('1', '1p')),
                                 self.net['net1'].input_layer(), self.batch_size,
                                 self.resource)
@@ -64,7 +64,7 @@ class TestPipelineSegment(TestPipelineFixture):
     def test_invalid_resource(self):
         ''' Invalid resource. '''
         with self.assertRaisesRegex(TypeError,
-                                     'PipelineSegment: .*resource.*'):
+                                    'PipelineSegment: .*resource.*'):
             _ = PipelineSegment((('0',), ('1', '1p')),
                                 self.net['net1'], self.batch_size,
                                 PhyDim2(1, 1))
@@ -197,11 +197,11 @@ class TestPipelineSegment(TestPipelineFixture):
 
         psr = self._make_segment((1, 2), net)._alloc_proc()
         nodes = [nr.dim.size() for nr in psr]
-        self.assertTrue(nodes == [24, 40] or nodes == [22, 42])
+        self.assertIn(nodes, ([24, 40], [22, 42]))
 
         psr = self._make_segment((1, 2, 3), net)._alloc_proc()
         nodes = [nr.dim.size() for nr in psr]
-        self.assertTrue(nodes == [12, 20, 32] or nodes == [10, 20, 34])
+        self.assertIn(nodes, ([12, 20, 32], [10, 20, 34]))
 
         # All segments.
 

--- a/nn_dataflow/tests/pipeline_test/test_pipeline_segment.py
+++ b/nn_dataflow/tests/pipeline_test/test_pipeline_segment.py
@@ -41,13 +41,13 @@ class TestPipelineSegment(TestPipelineFixture):
 
     def test_invalid_seg(self):
         ''' Invalid seg. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'PipelineSegment: .*seg.*tuple.*'):
             _ = PipelineSegment([('0',), ('1', '1p')],
                                 self.net['net1'], self.batch_size,
                                 self.resource)
 
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'PipelineSegment: .*seg.*sub-tuple.*'):
             _ = PipelineSegment(('0', '1', '1p'),
                                 self.net['net1'], self.batch_size,
@@ -55,7 +55,7 @@ class TestPipelineSegment(TestPipelineFixture):
 
     def test_invalid_network(self):
         ''' Invalid network. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'PipelineSegment: .*network.*'):
             _ = PipelineSegment((('0',), ('1', '1p')),
                                 self.net['net1'].input_layer(), self.batch_size,
@@ -63,7 +63,7 @@ class TestPipelineSegment(TestPipelineFixture):
 
     def test_invalid_resource(self):
         ''' Invalid resource. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'PipelineSegment: .*resource.*'):
             _ = PipelineSegment((('0',), ('1', '1p')),
                                 self.net['net1'], self.batch_size,

--- a/nn_dataflow/tests/pipeline_test/test_pipeline_segment_timing.py
+++ b/nn_dataflow/tests/pipeline_test/test_pipeline_segment_timing.py
@@ -45,7 +45,7 @@ class TestPipelineSegmentTiming(TestPipelineFixture):
     def test_invalid_network(self):
         ''' Invalid network. '''
         with self.assertRaisesRegex(TypeError,
-                                     'PipelineSegmentTiming: .*network.*'):
+                                    'PipelineSegmentTiming: .*network.*'):
             _ = PipelineSegmentTiming(self.net1.input_layer(), 3)
 
     def test_add(self):
@@ -118,11 +118,11 @@ class TestPipelineSegmentTiming(TestPipelineFixture):
         timing.add('0', self._make_sched_res((3, 0, 0), 123))
 
         with self.assertRaisesRegex(ValueError,
-                                     'PipelineSegmentTiming: .*belong to.*'):
+                                    'PipelineSegmentTiming: .*belong to.*'):
             timing.add('1', self._make_sched_res((2, 1, 0), 123))
 
         with self.assertRaisesRegex(ValueError,
-                                     'PipelineSegmentTiming: .*follow.*'):
+                                    'PipelineSegmentTiming: .*follow.*'):
             timing.add('1p', self._make_sched_res((3, 1, 1), 123))
 
     def test_add_already_in(self):
@@ -130,7 +130,7 @@ class TestPipelineSegmentTiming(TestPipelineFixture):
         timing = PipelineSegmentTiming(self.net1, 3)
         timing.add('0', self._make_sched_res((3, 0, 0), 123))
         with self.assertRaisesRegex(ValueError,
-                                     'PipelineSegmentTiming: .*layer 0.*'):
+                                    'PipelineSegmentTiming: .*layer 0.*'):
             timing.add('0', self._make_sched_res((3, 1, 0), 123))
 
     def test_time_bat_ngrp(self):

--- a/nn_dataflow/tests/pipeline_test/test_pipeline_segment_timing.py
+++ b/nn_dataflow/tests/pipeline_test/test_pipeline_segment_timing.py
@@ -44,7 +44,7 @@ class TestPipelineSegmentTiming(TestPipelineFixture):
 
     def test_invalid_network(self):
         ''' Invalid network. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'PipelineSegmentTiming: .*network.*'):
             _ = PipelineSegmentTiming(self.net1.input_layer(), 3)
 
@@ -117,11 +117,11 @@ class TestPipelineSegmentTiming(TestPipelineFixture):
         timing = PipelineSegmentTiming(self.net1, 3)
         timing.add('0', self._make_sched_res((3, 0, 0), 123))
 
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'PipelineSegmentTiming: .*belong to.*'):
             timing.add('1', self._make_sched_res((2, 1, 0), 123))
 
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'PipelineSegmentTiming: .*follow.*'):
             timing.add('1p', self._make_sched_res((3, 1, 1), 123))
 
@@ -129,7 +129,7 @@ class TestPipelineSegmentTiming(TestPipelineFixture):
         ''' add(), layer already in. '''
         timing = PipelineSegmentTiming(self.net1, 3)
         timing.add('0', self._make_sched_res((3, 0, 0), 123))
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'PipelineSegmentTiming: .*layer 0.*'):
             timing.add('0', self._make_sched_res((3, 1, 0), 123))
 

--- a/nn_dataflow/tests/tool_test/test_nn_dataflow_search.py
+++ b/nn_dataflow/tests/tool_test/test_nn_dataflow_search.py
@@ -28,7 +28,7 @@ class TestNNDataflowSearch(unittest.TestCase):
         self.assertTrue(os.path.isdir(
             os.path.join(self.cwd, 'nn_dataflow', 'tools')))
 
-        self.args = ['python', 'nn_dataflow/tools/nn_dataflow_search.py',
+        self.args = ['python', '-m', 'nn_dataflow.tools.nn_dataflow_search',
                      'alex_net', '--batch', '1',
                      '--node', '1', '1', '--array', '16', '16',
                      '--regf', '512', '--gbuf', '131072']
@@ -52,7 +52,10 @@ class TestNNDataflowSearch(unittest.TestCase):
         self.assertEqual(ret, 2)
 
     def _call(self, args):
-        return subprocess.call(args, cwd=self.cwd,
-                               stderr=subprocess.STDOUT,
-                               stdout=open(os.devnull, 'w'))
+        with open(os.devnull, 'w') as output:
+            result = subprocess.call(args, cwd=self.cwd,
+                                     stderr=subprocess.STDOUT,
+                                     stdout=output)
+            
+        return result
 

--- a/nn_dataflow/tests/tool_test/test_nn_dataflow_search.py
+++ b/nn_dataflow/tests/tool_test/test_nn_dataflow_search.py
@@ -56,6 +56,6 @@ class TestNNDataflowSearch(unittest.TestCase):
             result = subprocess.call(args, cwd=self.cwd,
                                      stderr=subprocess.STDOUT,
                                      stdout=output)
-            
+
         return result
 

--- a/nn_dataflow/tests/tool_test/test_nn_layer_stats.py
+++ b/nn_dataflow/tests/tool_test/test_nn_layer_stats.py
@@ -28,7 +28,7 @@ class TestNNLayerStats(unittest.TestCase):
         self.assertTrue(os.path.isdir(
             os.path.join(self.cwd, 'nn_dataflow', 'tools')))
 
-        self.args = ['python', 'nn_dataflow/tools/nn_layer_stats.py',
+        self.args = ['python', '-m', 'nn_dataflow.tools.nn_layer_stats',
                      'alex_net', '-b', '16']
 
     def test_default_invoke(self):
@@ -37,7 +37,9 @@ class TestNNLayerStats(unittest.TestCase):
         self.assertEqual(ret, 0)
 
     def _call(self, args):
-        return subprocess.call(args, cwd=self.cwd,
-                               stderr=subprocess.STDOUT,
-                               stdout=open(os.devnull, 'w'))
+        with open(os.devnull, 'w') as output:
+            result = subprocess.call(args, cwd=self.cwd,
+                                     stderr=subprocess.STDOUT,
+                                     stdout=output)
+        return result
 

--- a/nn_dataflow/tests/unit_test/test_buf_shr_scheme.py
+++ b/nn_dataflow/tests/unit_test/test_buf_shr_scheme.py
@@ -183,7 +183,7 @@ class TestBufShrScheme(unittest.TestCase):
     def test_mismatch_node_region(self):
         ''' Mismatched node region and part in constructor. '''
         # Smaller node region. Invalid.
-        with self.assertRaisesRegexp(ValueError, 'BufShrScheme: .*region.*'):
+        with self.assertRaisesRegex(ValueError, 'BufShrScheme: .*region.*'):
             _ = BufShrScheme(NodeRegion(origin=PhyDim2(0, 0),
                                         dim=PhyDim2(1, 1),
                                         type=NodeRegion.PROC),
@@ -242,7 +242,7 @@ class TestBufShrScheme(unittest.TestCase):
 
     def test_nhops_rotate_all_invalid(self):
         ''' Get nhops_rotate_all with invalid args. '''
-        with self.assertRaisesRegexp(ValueError, 'BufShrScheme: .*subgroup.*'):
+        with self.assertRaisesRegex(ValueError, 'BufShrScheme: .*subgroup.*'):
             _ = self.bufshr3.nhops_rotate_all(
                 de.FIL, self.bufshr3.size(de.FIL) + 1)
 
@@ -331,11 +331,11 @@ class TestBufShrScheme(unittest.TestCase):
 
     def test_nhops_wide_fetch_once_inv(self):
         ''' Get nhops_wide_fetch_once with invalid args. '''
-        with self.assertRaisesRegexp(ValueError, 'BufShrScheme: .*subgroup.*'):
+        with self.assertRaisesRegex(ValueError, 'BufShrScheme: .*subgroup.*'):
             _ = self.bufshr3.nhops_wide_fetch_once(
                 de.FIL, self.bufshr3.size(de.FIL) + 1, 2)
 
-        with self.assertRaisesRegexp(ValueError, 'BufShrScheme: .*width.*'):
+        with self.assertRaisesRegex(ValueError, 'BufShrScheme: .*width.*'):
             _ = self.bufshr3.nhops_wide_fetch_once(
                 de.FIL,
                 self.bufshr3.size(de.FIL) / 2,

--- a/nn_dataflow/tests/unit_test/test_cost.py
+++ b/nn_dataflow/tests/unit_test/test_cost.py
@@ -35,7 +35,7 @@ class TestCost(unittest.TestCase):
 
     def test_invalid_mac_op(self):
         ''' Invalid mac_op. '''
-        with self.assertRaisesRegexp(TypeError, 'Cost: .*mac_op.*'):
+        with self.assertRaisesRegex(TypeError, 'Cost: .*mac_op.*'):
             _ = Cost(mac_op=(1, 2),
                      mem_hier=(200, 6, 2, 1),
                      noc_hop=10,
@@ -44,13 +44,13 @@ class TestCost(unittest.TestCase):
 
     def test_invalid_mem_hier_type(self):
         ''' Invalid mem_hier type. '''
-        with self.assertRaisesRegexp(TypeError, 'Cost: .*mem_hier.*'):
+        with self.assertRaisesRegex(TypeError, 'Cost: .*mem_hier.*'):
             _ = Cost(mac_op=1,
                      mem_hier=200,
                      noc_hop=10,
                      idl_unit=0,
                     )
-        with self.assertRaisesRegexp(TypeError, 'Cost: .*mem_hier.*'):
+        with self.assertRaisesRegex(TypeError, 'Cost: .*mem_hier.*'):
             _ = Cost(mac_op=1,
                      mem_hier=[200, 6, 2, 1],
                      noc_hop=10,
@@ -59,7 +59,7 @@ class TestCost(unittest.TestCase):
 
     def test_invalid_mem_hier_len(self):
         ''' Invalid mem_hier len. '''
-        with self.assertRaisesRegexp(ValueError, 'Cost: .*mem_hier.*'):
+        with self.assertRaisesRegex(ValueError, 'Cost: .*mem_hier.*'):
             _ = Cost(mac_op=1,
                      mem_hier=(200, 6),
                      noc_hop=10,
@@ -68,7 +68,7 @@ class TestCost(unittest.TestCase):
 
     def test_invalid_noc_hop(self):
         ''' Invalid noc_hop. '''
-        with self.assertRaisesRegexp(TypeError, 'Cost: .*noc_hop.*'):
+        with self.assertRaisesRegex(TypeError, 'Cost: .*noc_hop.*'):
             _ = Cost(mac_op=1,
                      mem_hier=(200, 6, 2, 1),
                      noc_hop=[10, 10],
@@ -77,7 +77,7 @@ class TestCost(unittest.TestCase):
 
     def test_invalid_idl_unit(self):
         ''' Invalid idl_unit. '''
-        with self.assertRaisesRegexp(TypeError, 'Cost: .*idl_unit.*'):
+        with self.assertRaisesRegex(TypeError, 'Cost: .*idl_unit.*'):
             _ = Cost(mac_op=1,
                      mem_hier=(200, 6, 2, 1),
                      noc_hop=10,

--- a/nn_dataflow/tests/unit_test/test_data_dim_loops.py
+++ b/nn_dataflow/tests/unit_test/test_data_dim_loops.py
@@ -40,11 +40,11 @@ class TestDataDimLoops(unittest.TestCase):
 
     def test_invalid_args(self):
         ''' Invalid arguments. '''
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'DataDimLoops: .*LoopEnum.*'):
             _ = DataDimLoops(le.NUM + 1)
 
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'DataDimLoops: .*LoopEnum.*'):
             _ = DataDimLoops(le.IFM, le.NUM)
 

--- a/nn_dataflow/tests/unit_test/test_data_dim_loops.py
+++ b/nn_dataflow/tests/unit_test/test_data_dim_loops.py
@@ -41,11 +41,11 @@ class TestDataDimLoops(unittest.TestCase):
     def test_invalid_args(self):
         ''' Invalid arguments. '''
         with self.assertRaisesRegex(ValueError,
-                                     'DataDimLoops: .*LoopEnum.*'):
+                                    'DataDimLoops: .*LoopEnum.*'):
             _ = DataDimLoops(le.NUM + 1)
 
         with self.assertRaisesRegex(ValueError,
-                                     'DataDimLoops: .*LoopEnum.*'):
+                                    'DataDimLoops: .*LoopEnum.*'):
             _ = DataDimLoops(le.IFM, le.NUM)
 
     def test_loops(self):

--- a/nn_dataflow/tests/unit_test/test_data_layout.py
+++ b/nn_dataflow/tests/unit_test/test_data_layout.py
@@ -49,31 +49,31 @@ class TestDataLayout(unittest.TestCase):
 
     def test_invalid_args(self):
         ''' Invalid arguments. '''
-        with self.assertRaisesRegexp(TypeError, 'DataLayout: .*frngs.*'):
+        with self.assertRaisesRegex(TypeError, 'DataLayout: .*frngs.*'):
             _ = DataLayout(frngs=None,
                            regions=(self.region1,),
                            parts=(self.part1,))
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'DataLayout: .*elements in frngs.*'):
             _ = DataLayout(frngs=(None,),
                            regions=(self.region1,),
                            parts=(self.part1,))
 
-        with self.assertRaisesRegexp(TypeError, 'DataLayout: .*regions.*'):
+        with self.assertRaisesRegex(TypeError, 'DataLayout: .*regions.*'):
             _ = DataLayout(frngs=(self.frng1,),
                            regions=None,
                            parts=(self.part1,))
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'DataLayout: .*elements in regions.*'):
             _ = DataLayout(frngs=(self.frng1,),
                            regions=self.region1,
                            parts=(self.part1,))
 
-        with self.assertRaisesRegexp(TypeError, 'DataLayout: .*parts.*'):
+        with self.assertRaisesRegex(TypeError, 'DataLayout: .*parts.*'):
             _ = DataLayout(frngs=(self.frng1,),
                            regions=(self.region1,),
                            parts=None)
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'DataLayout: .*elements in parts.*'):
             _ = DataLayout(frngs=(self.frng1,),
                            regions=(self.region1,),
@@ -82,37 +82,37 @@ class TestDataLayout(unittest.TestCase):
     def test_invalid_frngs(self):
         ''' Invalid frngs. '''
         # No frngs.
-        with self.assertRaisesRegexp(ValueError, 'DataLayout: .*frng.*'):
+        with self.assertRaisesRegex(ValueError, 'DataLayout: .*frng.*'):
             _ = DataLayout(frngs=tuple(),
                            regions=(self.region1,),
                            parts=(self.part1,))
 
         # Not begin at 0.
-        with self.assertRaisesRegexp(ValueError, 'DataLayout: .*frng.*'):
+        with self.assertRaisesRegex(ValueError, 'DataLayout: .*frng.*'):
             _ = DataLayout(frngs=(FmapRange((0, 4, 0, 0), (4, 8, 16, 16)),
                                   self.frng1),
                            regions=(self.region1, self.region2),
                            parts=(self.part1, self.part2))
 
         # b, h, w mismatch.
-        with self.assertRaisesRegexp(ValueError, 'DataLayout: .*frng.*'):
+        with self.assertRaisesRegex(ValueError, 'DataLayout: .*frng.*'):
             _ = DataLayout(frngs=(self.frng1,
                                   FmapRange((0, 4, 0, 0), (3, 8, 16, 16))),
                            regions=(self.region1, self.region2),
                            parts=(self.part1, self.part2))
-        with self.assertRaisesRegexp(ValueError, 'DataLayout: .*frng.*'):
+        with self.assertRaisesRegex(ValueError, 'DataLayout: .*frng.*'):
             _ = DataLayout(frngs=(self.frng1,
                                   FmapRange((0, 4, 0, 0), (4, 8, 12, 16))),
                            regions=(self.region1, self.region2),
                            parts=(self.part1, self.part2))
-        with self.assertRaisesRegexp(ValueError, 'DataLayout: .*frng.*'):
+        with self.assertRaisesRegex(ValueError, 'DataLayout: .*frng.*'):
             _ = DataLayout(frngs=(self.frng1,
                                   FmapRange((0, 4, 0, 0), (4, 8, 16, 12))),
                            regions=(self.region1, self.region2),
                            parts=(self.part1, self.part2))
 
         # n discontinuous.
-        with self.assertRaisesRegexp(ValueError, 'DataLayout: .*frng.*'):
+        with self.assertRaisesRegex(ValueError, 'DataLayout: .*frng.*'):
             _ = DataLayout(frngs=(self.frng1,
                                   FmapRange((0, 5, 0, 0), (4, 8, 16, 16))),
                            regions=(self.region1, self.region2),
@@ -120,7 +120,7 @@ class TestDataLayout(unittest.TestCase):
 
     def test_invalid_parts(self):
         ''' Invalid parts. '''
-        with self.assertRaisesRegexp(ValueError, 'DataLayout: .*part.*'):
+        with self.assertRaisesRegex(ValueError, 'DataLayout: .*part.*'):
             _ = DataLayout(frngs=(self.frng1,),
                            regions=(self.region1,),
                            parts=(PartitionScheme(order=range(pe.NUM),
@@ -129,7 +129,7 @@ class TestDataLayout(unittest.TestCase):
                                                          PhyDim2(1, 1),
                                                          PhyDim2(2, 1))),))
 
-        with self.assertRaisesRegexp(ValueError, 'DataLayout: .*part.*'):
+        with self.assertRaisesRegex(ValueError, 'DataLayout: .*part.*'):
             _ = DataLayout(frngs=(self.frng1,
                                   FmapRange((0, 4, 0, 0), (4, 8, 16, 16))),
                            regions=(self.region2, self.region1),
@@ -137,7 +137,7 @@ class TestDataLayout(unittest.TestCase):
 
     def test_invalid_args_length(self):
         ''' Invalid args length. '''
-        with self.assertRaisesRegexp(ValueError, 'DataLayout: .*length.*'):
+        with self.assertRaisesRegex(ValueError, 'DataLayout: .*length.*'):
             _ = DataLayout(frngs=(self.frng1,),
                            regions=(self.region1, self.region2),
                            parts=(self.part1,))
@@ -255,7 +255,7 @@ class TestDataLayout(unittest.TestCase):
     def test_nhops_to_invalid_kwargs(self):
         ''' Get nhops_to invalid kwargs. '''
         fr = FmapRange((0,) * 4, (4, 4, 16, 16))
-        with self.assertRaisesRegexp(ValueError, 'DataLayout: .*keyword.*'):
+        with self.assertRaisesRegex(ValueError, 'DataLayout: .*keyword.*'):
             _ = self.dl1.nhops_to(fr, PhyDim2(1, 1), f=True)
 
     def test_is_in(self):
@@ -348,9 +348,9 @@ class TestDataLayout(unittest.TestCase):
 
     def test_concat_invalid_type(self):
         ''' Concat invalid type. '''
-        with self.assertRaisesRegexp(TypeError, 'DataLayout: .*concat.*'):
+        with self.assertRaisesRegex(TypeError, 'DataLayout: .*concat.*'):
             _ = DataLayout.concat(self.dl1, self.frng1)
-        with self.assertRaisesRegexp(TypeError, 'DataLayout: .*concat.*'):
+        with self.assertRaisesRegex(TypeError, 'DataLayout: .*concat.*'):
             _ = DataLayout.concat(self.dl1, PhyDim2(1, 3))
 
     def test_concat_unmatch(self):
@@ -361,6 +361,6 @@ class TestDataLayout(unittest.TestCase):
             dl = DataLayout(frngs=(fr,), regions=(self.region1,),
                             parts=(self.part1,))
 
-            with self.assertRaisesRegexp(ValueError, 'DataLayout: .*match.*'):
+            with self.assertRaisesRegex(ValueError, 'DataLayout: .*match.*'):
                 _ = DataLayout.concat(self.dl1, dl)
 

--- a/nn_dataflow/tests/unit_test/test_data_layout.py
+++ b/nn_dataflow/tests/unit_test/test_data_layout.py
@@ -54,7 +54,7 @@ class TestDataLayout(unittest.TestCase):
                            regions=(self.region1,),
                            parts=(self.part1,))
         with self.assertRaisesRegex(TypeError,
-                                     'DataLayout: .*elements in frngs.*'):
+                                    'DataLayout: .*elements in frngs.*'):
             _ = DataLayout(frngs=(None,),
                            regions=(self.region1,),
                            parts=(self.part1,))
@@ -64,7 +64,7 @@ class TestDataLayout(unittest.TestCase):
                            regions=None,
                            parts=(self.part1,))
         with self.assertRaisesRegex(TypeError,
-                                     'DataLayout: .*elements in regions.*'):
+                                    'DataLayout: .*elements in regions.*'):
             _ = DataLayout(frngs=(self.frng1,),
                            regions=self.region1,
                            parts=(self.part1,))
@@ -74,7 +74,7 @@ class TestDataLayout(unittest.TestCase):
                            regions=(self.region1,),
                            parts=None)
         with self.assertRaisesRegex(TypeError,
-                                     'DataLayout: .*elements in parts.*'):
+                                    'DataLayout: .*elements in parts.*'):
             _ = DataLayout(frngs=(self.frng1,),
                            regions=(self.region1,),
                            parts=self.part1)

--- a/nn_dataflow/tests/unit_test/test_fmap_range.py
+++ b/nn_dataflow/tests/unit_test/test_fmap_range.py
@@ -193,8 +193,6 @@ class TestFmapRange(unittest.TestCase):
         fr4 = FmapRange((0, 0, 0, 0), (0, 0, 0, 0))
         self.assertEqual(fr3, fr4)
 
-        _ = fr1 == 4
-
     def test_ne(self):
         ''' Whether ne. '''
         fr1 = FmapRange((1, 2, 3, 4), (5, 7, 11, 13))

--- a/nn_dataflow/tests/unit_test/test_fmap_range.py
+++ b/nn_dataflow/tests/unit_test/test_fmap_range.py
@@ -31,7 +31,7 @@ class TestFmapRange(unittest.TestCase):
 
     def test_invalid_beg_end(self):
         ''' Invalid fp_beg/fp_end. '''
-        with self.assertRaisesRegexp(ValueError, 'FmapRange: .*beg.*end.*'):
+        with self.assertRaisesRegex(ValueError, 'FmapRange: .*beg.*end.*'):
             _ = FmapRange((0, 0, 0, 0), (3, -5, 7, 11))
 
     def test_valid_zero_range(self):
@@ -107,7 +107,7 @@ class TestFmapRange(unittest.TestCase):
     def test_overlap_error(self):
         ''' Get overlap error. '''
         fr1 = FmapRange((-11, -4, 3, 0), (3, 5, 7, 11))
-        with self.assertRaisesRegexp(TypeError, 'FmapRange: .*'):
+        with self.assertRaisesRegex(TypeError, 'FmapRange: .*'):
             fr1.overlap(((0,) * 4, (2,) * 4))
 
     def test_overlap_size(self):
@@ -126,7 +126,7 @@ class TestFmapRange(unittest.TestCase):
     def test_overlap_size_error(self):
         ''' Get overlap_size error. '''
         fr1 = FmapRange((-11, -4, 3, 0), (3, 5, 7, 11))
-        with self.assertRaisesRegexp(TypeError, 'FmapRange: .*'):
+        with self.assertRaisesRegex(TypeError, 'FmapRange: .*'):
             fr1.overlap_size(((0,) * 4, (2,) * 4))
 
     def test_contains(self):
@@ -157,45 +157,19 @@ class TestFmapRange(unittest.TestCase):
             self.assertLessEqual(lst[idx], lst[idx])
             self.assertGreaterEqual(lst[idx], lst[idx])
 
-    def test_compare_notimplemented(self):
-        ''' Comparison with types not implemented. '''
-        ins1 = FmapRange((-11, -4, 3, 0), (3, 5, 7, 11))
-        ins2 = (3, 5, 7, 11)
-        ins3 = None
-        # The default comparison gives a consistent but arbitrary order.
-        # https://docs.python.org/2/reference/expressions.html#value-comparisons
-
-        sort = sorted([ins1, ins2, ins3])
-
-        self.assertGreater(sort[2], sort[1])
-        self.assertGreater(sort[2], sort[0])
-        self.assertGreater(sort[1], sort[0])
-        self.assertLess(sort[0], sort[1])
-        self.assertLess(sort[0], sort[2])
-        self.assertLess(sort[1], sort[2])
-        self.assertGreaterEqual(sort[2], sort[1])
-        self.assertGreaterEqual(sort[2], sort[0])
-        self.assertGreaterEqual(sort[1], sort[0])
-        self.assertLessEqual(sort[0], sort[1])
-        self.assertLessEqual(sort[0], sort[2])
-        self.assertLessEqual(sort[1], sort[2])
-        self.assertNotEqual(sort[0], sort[1])
-        self.assertNotEqual(sort[0], sort[2])
-        self.assertNotEqual(sort[1], sort[2])
-
     def test_compare_overlap(self):
         ''' Comparison with overlapping FmapRange. '''
         fr1 = FmapRange((-11, -4, 3, 0), (3, 5, 7, 11))
         fr2 = FmapRange((-11, -4, 3, 0), (1, 1, 5, 5))
         fr3 = FmapRange((0, 0, 3, 1), (1, 1, 5, 5))
         fr4 = FmapRange((0, 0, 3, 1), (3, 5, 7, 11))
-        with self.assertRaisesRegexp(ValueError, 'FmapRange: .*overlap.*'):
+        with self.assertRaisesRegex(ValueError, 'FmapRange: .*overlap.*'):
             _ = fr1 < fr2
-        with self.assertRaisesRegexp(ValueError, 'FmapRange: .*overlap.*'):
+        with self.assertRaisesRegex(ValueError, 'FmapRange: .*overlap.*'):
             _ = fr1 >= fr2
-        with self.assertRaisesRegexp(ValueError, 'FmapRange: .*overlap.*'):
+        with self.assertRaisesRegex(ValueError, 'FmapRange: .*overlap.*'):
             _ = fr1 <= fr3
-        with self.assertRaisesRegexp(ValueError, 'FmapRange: .*overlap.*'):
+        with self.assertRaisesRegex(ValueError, 'FmapRange: .*overlap.*'):
             _ = fr1 < fr4
 
     def test_compare_empty(self):
@@ -274,7 +248,7 @@ class TestFmapRangeMap(unittest.TestCase):
 
     def test_add_overlap_fr(self):
         ''' Modifier add overlapping FmapRange. '''
-        with self.assertRaisesRegexp(ValueError, 'FmapRangeMap: .*overlap.*'):
+        with self.assertRaisesRegex(ValueError, 'FmapRangeMap: .*overlap.*'):
             self.frm.add(FmapRange((3, 7, 15, 15), (5, 9, 17, 17)), 10)
 
     def test_get(self):
@@ -286,7 +260,7 @@ class TestFmapRangeMap(unittest.TestCase):
 
     def test_get_not_in(self):
         ''' Get not in. '''
-        with self.assertRaisesRegexp(KeyError, 'FmapRangeMap: .*key.*'):
+        with self.assertRaisesRegex(KeyError, 'FmapRangeMap: .*key.*'):
             _ = self.frm.get(FmapPosition(4, 8, 16, 16))
 
     def test_complete_fmap_range(self):
@@ -305,14 +279,14 @@ class TestFmapRangeMap(unittest.TestCase):
         ''' Get complete_fmap_range incomplete. '''
         self.frm.add(FmapRange((4, 8, 16, 16), (5, 9, 17, 17)), 10)
         self.assertFalse(self.frm.is_complete(), 'is_complete: incomplete')
-        with self.assertRaisesRegexp(ValueError, 'FmapRangeMap: .*complete.*'):
+        with self.assertRaisesRegex(ValueError, 'FmapRangeMap: .*complete.*'):
             _ = self.frm.complete_fmap_range()
 
         fr = FmapRange((1, 0, 0, 0), (3, 5, 7, 9))
         frm = FmapRangeMap()
         frm.add(fr, 3.4)
         self.assertFalse(frm.is_complete(), 'is_complete: incomplete')
-        with self.assertRaisesRegexp(ValueError, 'FmapRangeMap: .*complete.*'):
+        with self.assertRaisesRegex(ValueError, 'FmapRangeMap: .*complete.*'):
             _ = frm.complete_fmap_range()
 
     def test_items(self):
@@ -332,13 +306,13 @@ class TestFmapRangeMap(unittest.TestCase):
         fr1 = FmapRange((10, 10, 10, 10), (11, 11, 11, 11))
         frm.add(fr1, 10)
         self.assertEqual(frm.get(fr1.fp_beg), 10, 'copy: in')
-        with self.assertRaisesRegexp(KeyError, 'FmapRangeMap: .*key.*'):
+        with self.assertRaisesRegex(KeyError, 'FmapRangeMap: .*key.*'):
             _ = self.frm.get(fr1.fp_beg)
 
         fr2 = FmapRange((20, 20, 20, 20), (21, 21, 21, 21))
         self.frm.add(fr2, 20)
         self.assertEqual(self.frm.get(fr2.fp_beg), 20, 'copy: in')
-        with self.assertRaisesRegexp(KeyError, 'FmapRangeMap: .*key.*'):
+        with self.assertRaisesRegex(KeyError, 'FmapRangeMap: .*key.*'):
             _ = frm.get(fr2.fp_beg)
 
     def test_rget_counter(self):
@@ -378,7 +352,7 @@ class TestFmapRangeMap(unittest.TestCase):
 
     def test_rget_single_multi(self):
         ''' Get rget_single with . '''
-        with self.assertRaisesRegexp(ValueError, 'FmapRangeMap: .*single.*'):
+        with self.assertRaisesRegex(ValueError, 'FmapRangeMap: .*single.*'):
             _ = self.frm.rget_single(FmapRange((3, 1, 10, 3), (4, 6, 13, 7)))
 
     def test_str(self):

--- a/nn_dataflow/tests/unit_test/test_int_range.py
+++ b/nn_dataflow/tests/unit_test/test_int_range.py
@@ -34,14 +34,14 @@ class TestIntRange(unittest.TestCase):
 
     def test_invalid_args(self):
         ''' Invalid arguments. '''
-        with self.assertRaisesRegexp(TypeError, 'IntRange: .*beg.*'):
+        with self.assertRaisesRegex(TypeError, 'IntRange: .*beg.*'):
             _ = IntRange(7.2, 3)
-        with self.assertRaisesRegexp(TypeError, 'IntRange: .*end.*'):
+        with self.assertRaisesRegex(TypeError, 'IntRange: .*end.*'):
             _ = IntRange(7, None)
 
-        with self.assertRaisesRegexp(ValueError, 'IntRange: .*beg.*end.*'):
+        with self.assertRaisesRegex(ValueError, 'IntRange: .*beg.*end.*'):
             _ = IntRange(7, 3)
-        with self.assertRaisesRegexp(ValueError, 'IntRange: .*beg.*end.*'):
+        with self.assertRaisesRegex(ValueError, 'IntRange: .*beg.*end.*'):
             _ = IntRange(-3, -7)
 
     def test_size(self):
@@ -90,7 +90,7 @@ class TestIntRange(unittest.TestCase):
     def test_overlap_error(self):
         ''' Get overlap error. '''
         ir = IntRange(-11, 5)
-        with self.assertRaisesRegexp(TypeError, 'IntRange: .*'):
+        with self.assertRaisesRegex(TypeError, 'IntRange: .*'):
             ir.overlap((0, 1))
 
     def test_offset(self):

--- a/nn_dataflow/tests/unit_test/test_layer.py
+++ b/nn_dataflow/tests/unit_test/test_layer.py
@@ -56,7 +56,7 @@ class TestLayer(unittest.TestCase):
 
     def test_invalid_sofm(self):
         ''' Invalid sofm. '''
-        with self.assertRaisesRegexp(ValueError, 'Layer: .*sofm.*'):
+        with self.assertRaisesRegex(ValueError, 'Layer: .*sofm.*'):
             _ = ConvLayer(3, 64, [28, 14, 7], 3)
 
     def test_diff_hwtrd(self):
@@ -67,7 +67,7 @@ class TestLayer(unittest.TestCase):
 
     def test_invalid_strd(self):
         ''' Invalid stride. '''
-        with self.assertRaisesRegexp(ValueError, 'Layer: .*strd.*'):
+        with self.assertRaisesRegex(ValueError, 'Layer: .*strd.*'):
             _ = ConvLayer(3, 64, 28, 3, strd=[2, 3, 4])
 
     def test_ifmap(self):
@@ -160,7 +160,7 @@ class TestLayer(unittest.TestCase):
     def test_is_valid_padding_sifm_inv(self):
         ''' Invalid argument for is_valid_padding_sifm. '''
         clayer = ConvLayer(3, 64, 28, 3, strd=2)
-        with self.assertRaisesRegexp(ValueError, 'Layer: .*sifm.*'):
+        with self.assertRaisesRegex(ValueError, 'Layer: .*sifm.*'):
             _ = clayer.is_valid_padding_sifm([3])
 
     def test_eq(self):
@@ -291,7 +291,7 @@ class TestConvLayer(unittest.TestCase):
 
     def test_filter_size_invalid(self):
         ''' Invalid filter size. '''
-        with self.assertRaisesRegexp(ValueError, 'ConvLayer: .*sfil.*'):
+        with self.assertRaisesRegex(ValueError, 'ConvLayer: .*sfil.*'):
             _ = ConvLayer(3, 64, [28, 14], [3, 3, 3])
 
     def test_fclayer(self):
@@ -350,12 +350,12 @@ class TestLocalRegionLayer(unittest.TestCase):
 
     def test_invalid_sreg(self):
         ''' Invalid region size. '''
-        with self.assertRaisesRegexp(ValueError, 'LocalRegionLayer: .*sreg.*'):
+        with self.assertRaisesRegex(ValueError, 'LocalRegionLayer: .*sreg.*'):
             _ = LocalRegionLayer(64, 28, 1, [2, 4, 6])
 
     def test_mix_sreg(self):
         ''' Mix region of n-dimension and h/w-dimension. '''
-        with self.assertRaisesRegexp(ValueError, 'LocalRegionLayer: .*mix.*'):
+        with self.assertRaisesRegex(ValueError, 'LocalRegionLayer: .*mix.*'):
             _ = LocalRegionLayer(64, 28, 2, 2)
 
     def test_poolinglayer(self):

--- a/nn_dataflow/tests/unit_test/test_nested_loop_desc.py
+++ b/nn_dataflow/tests/unit_test/test_nested_loop_desc.py
@@ -57,7 +57,7 @@ class TestNestedLoopDesc(unittest.TestCase):
 
     def test_invalid_loopcnt_type(self):
         ''' Invalid loopcnt type. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'NestedLoopDesc: .*loopcnt.*'):
             _ = NestedLoopDesc(loopcnt=[3, 8, 4],
                                usize_gbuf=(20, 30, 9),
@@ -75,7 +75,7 @@ class TestNestedLoopDesc(unittest.TestCase):
 
     def test_invalid_loopcnt_len(self):
         ''' Invalid loopcnt len. '''
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'NestedLoopDesc: .*loopcnt.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8),
                                usize_gbuf=(20, 30, 9),
@@ -93,7 +93,7 @@ class TestNestedLoopDesc(unittest.TestCase):
 
     def test_invalid_usize_gbuf_type(self):
         ''' Invalid usize_gbuf type. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'NestedLoopDesc: .*usize_gbuf.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=[20, 30, 9],
@@ -111,7 +111,7 @@ class TestNestedLoopDesc(unittest.TestCase):
 
     def test_invalid_usize_gbuf_len(self):
         ''' Invalid usize_gbuf len. '''
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'NestedLoopDesc: .*usize_gbuf.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30),
@@ -129,7 +129,7 @@ class TestNestedLoopDesc(unittest.TestCase):
 
     def test_invalid_usize_regf_type(self):
         ''' Invalid usize_regf type. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'NestedLoopDesc: .*usize_regf.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
@@ -147,7 +147,7 @@ class TestNestedLoopDesc(unittest.TestCase):
 
     def test_invalid_usize_regf_len(self):
         ''' Invalid usize_regf len. '''
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'NestedLoopDesc: .*usize_regf.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
@@ -165,7 +165,7 @@ class TestNestedLoopDesc(unittest.TestCase):
 
     def test_invalid_unit_access_type(self):
         ''' Invalid unit_access type. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'NestedLoopDesc: .*unit_access.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
@@ -180,7 +180,7 @@ class TestNestedLoopDesc(unittest.TestCase):
                                unit_ops=7,
                                unit_time=7
                               )
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'NestedLoopDesc: .*unit_access.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
@@ -198,7 +198,7 @@ class TestNestedLoopDesc(unittest.TestCase):
 
     def test_invalid_unit_access_len(self):
         ''' Invalid unit_access len. '''
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'NestedLoopDesc: .*unit_access.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
@@ -212,7 +212,7 @@ class TestNestedLoopDesc(unittest.TestCase):
                                unit_ops=7,
                                unit_time=7
                               )
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'NestedLoopDesc: .*unit_access.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
@@ -292,7 +292,7 @@ class TestNestedLoopDesc(unittest.TestCase):
 
     def test_invalid_data_loops_type(self):
         ''' Invalid data_loops type. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'NestedLoopDesc: .*data_loops.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
@@ -307,7 +307,7 @@ class TestNestedLoopDesc(unittest.TestCase):
                                unit_ops=7,
                                unit_time=7
                               )
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'NestedLoopDesc: .*data_loops.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
@@ -325,7 +325,7 @@ class TestNestedLoopDesc(unittest.TestCase):
 
     def test_invalid_data_loops_len(self):
         ''' Invalid data_loops len. '''
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'NestedLoopDesc: .*data_loops.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),

--- a/nn_dataflow/tests/unit_test/test_nested_loop_desc.py
+++ b/nn_dataflow/tests/unit_test/test_nested_loop_desc.py
@@ -58,7 +58,7 @@ class TestNestedLoopDesc(unittest.TestCase):
     def test_invalid_loopcnt_type(self):
         ''' Invalid loopcnt type. '''
         with self.assertRaisesRegex(TypeError,
-                                     'NestedLoopDesc: .*loopcnt.*'):
+                                    'NestedLoopDesc: .*loopcnt.*'):
             _ = NestedLoopDesc(loopcnt=[3, 8, 4],
                                usize_gbuf=(20, 30, 9),
                                usize_regf=(3, 3, 1),
@@ -76,7 +76,7 @@ class TestNestedLoopDesc(unittest.TestCase):
     def test_invalid_loopcnt_len(self):
         ''' Invalid loopcnt len. '''
         with self.assertRaisesRegex(ValueError,
-                                     'NestedLoopDesc: .*loopcnt.*'):
+                                    'NestedLoopDesc: .*loopcnt.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8),
                                usize_gbuf=(20, 30, 9),
                                usize_regf=(3, 3, 1),
@@ -94,7 +94,7 @@ class TestNestedLoopDesc(unittest.TestCase):
     def test_invalid_usize_gbuf_type(self):
         ''' Invalid usize_gbuf type. '''
         with self.assertRaisesRegex(TypeError,
-                                     'NestedLoopDesc: .*usize_gbuf.*'):
+                                    'NestedLoopDesc: .*usize_gbuf.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=[20, 30, 9],
                                usize_regf=(3, 3, 1),
@@ -112,7 +112,7 @@ class TestNestedLoopDesc(unittest.TestCase):
     def test_invalid_usize_gbuf_len(self):
         ''' Invalid usize_gbuf len. '''
         with self.assertRaisesRegex(ValueError,
-                                     'NestedLoopDesc: .*usize_gbuf.*'):
+                                    'NestedLoopDesc: .*usize_gbuf.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30),
                                usize_regf=(3, 3, 1),
@@ -130,7 +130,7 @@ class TestNestedLoopDesc(unittest.TestCase):
     def test_invalid_usize_regf_type(self):
         ''' Invalid usize_regf type. '''
         with self.assertRaisesRegex(TypeError,
-                                     'NestedLoopDesc: .*usize_regf.*'):
+                                    'NestedLoopDesc: .*usize_regf.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
                                usize_regf=[3, 3, 1],
@@ -148,7 +148,7 @@ class TestNestedLoopDesc(unittest.TestCase):
     def test_invalid_usize_regf_len(self):
         ''' Invalid usize_regf len. '''
         with self.assertRaisesRegex(ValueError,
-                                     'NestedLoopDesc: .*usize_regf.*'):
+                                    'NestedLoopDesc: .*usize_regf.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
                                usize_regf=(3, 3),
@@ -166,7 +166,7 @@ class TestNestedLoopDesc(unittest.TestCase):
     def test_invalid_unit_access_type(self):
         ''' Invalid unit_access type. '''
         with self.assertRaisesRegex(TypeError,
-                                     'NestedLoopDesc: .*unit_access.*'):
+                                    'NestedLoopDesc: .*unit_access.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
                                usize_regf=(3, 3, 1),
@@ -181,7 +181,7 @@ class TestNestedLoopDesc(unittest.TestCase):
                                unit_time=7
                               )
         with self.assertRaisesRegex(TypeError,
-                                     'NestedLoopDesc: .*unit_access.*'):
+                                    'NestedLoopDesc: .*unit_access.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
                                usize_regf=(3, 3, 1),
@@ -199,7 +199,7 @@ class TestNestedLoopDesc(unittest.TestCase):
     def test_invalid_unit_access_len(self):
         ''' Invalid unit_access len. '''
         with self.assertRaisesRegex(ValueError,
-                                     'NestedLoopDesc: .*unit_access.*'):
+                                    'NestedLoopDesc: .*unit_access.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
                                usize_regf=(3, 3, 1),
@@ -213,7 +213,7 @@ class TestNestedLoopDesc(unittest.TestCase):
                                unit_time=7
                               )
         with self.assertRaisesRegex(ValueError,
-                                     'NestedLoopDesc: .*unit_access.*'):
+                                    'NestedLoopDesc: .*unit_access.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
                                usize_regf=(3, 3, 1),
@@ -293,7 +293,7 @@ class TestNestedLoopDesc(unittest.TestCase):
     def test_invalid_data_loops_type(self):
         ''' Invalid data_loops type. '''
         with self.assertRaisesRegex(TypeError,
-                                     'NestedLoopDesc: .*data_loops.*'):
+                                    'NestedLoopDesc: .*data_loops.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
                                usize_regf=(3, 3, 1),
@@ -308,7 +308,7 @@ class TestNestedLoopDesc(unittest.TestCase):
                                unit_time=7
                               )
         with self.assertRaisesRegex(TypeError,
-                                     'NestedLoopDesc: .*data_loops.*'):
+                                    'NestedLoopDesc: .*data_loops.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
                                usize_regf=(3, 3, 1),
@@ -326,7 +326,7 @@ class TestNestedLoopDesc(unittest.TestCase):
     def test_invalid_data_loops_len(self):
         ''' Invalid data_loops len. '''
         with self.assertRaisesRegex(ValueError,
-                                     'NestedLoopDesc: .*data_loops.*'):
+                                    'NestedLoopDesc: .*data_loops.*'):
             _ = NestedLoopDesc(loopcnt=(3, 8, 4),
                                usize_gbuf=(20, 30, 9),
                                usize_regf=(3, 3, 1),

--- a/nn_dataflow/tests/unit_test/test_network.py
+++ b/nn_dataflow/tests/unit_test/test_network.py
@@ -106,11 +106,11 @@ class TestNetwork(unittest.TestCase):
         network.add('c1', ConvLayer(3, 64, 224, 3))
 
         with self.assertRaisesRegex(ValueError,
-                                     'Network: .*c1.*p1.*mismatch fmap.*'):
+                                    'Network: .*c1.*p1.*mismatch fmap.*'):
             network.add('p1', PoolingLayer(64, 7, 2))
         self.assertEqual(len(network), 1)
         with self.assertRaisesRegex(ValueError,
-                                     'Network: .*c1.*c2.*mismatch fmap.*'):
+                                    'Network: .*c1.*c2.*mismatch fmap.*'):
             network.add('c2', ConvLayer(64, 128, 220, 3))
         self.assertEqual(len(network), 1)
 
@@ -124,7 +124,7 @@ class TestNetwork(unittest.TestCase):
         network.add('c2', ConvLayer(64, 128, 224, 3))
 
         with self.assertRaisesRegex(ValueError,
-                                     r'Network: .*c1 | c2.*prev.*p1.*'):
+                                    r'Network: .*c1 | c2.*prev.*p1.*'):
             network.add('p1', PoolingLayer(128, 7, 32), prevs=('c1', 'c2'))
         self.assertEqual(len(network), 2)
 

--- a/nn_dataflow/tests/unit_test/test_network.py
+++ b/nn_dataflow/tests/unit_test/test_network.py
@@ -44,16 +44,16 @@ class TestNetwork(unittest.TestCase):
     def test_set_input_layer_type(self):
         ''' Modifier set_input_layer type. '''
         network = Network('test_net')
-        with self.assertRaisesRegexp(TypeError, 'Network: .*input_layer.*'):
+        with self.assertRaisesRegex(TypeError, 'Network: .*input_layer.*'):
             network.set_input_layer(Layer(3, 24))
-        with self.assertRaisesRegexp(TypeError, 'Network: .*input_layer.*'):
+        with self.assertRaisesRegex(TypeError, 'Network: .*input_layer.*'):
             network.set_input_layer(ConvLayer(3, 8, 24, 3))
 
     def test_set_input_layer_duplicate(self):
         ''' Modifier set_input_layer duplicate. '''
         network = Network('test_net')
         network.set_input_layer(InputLayer(3, 24))
-        with self.assertRaisesRegexp(KeyError, 'Network: .*input.*'):
+        with self.assertRaisesRegex(KeyError, 'Network: .*input.*'):
             network.set_input_layer(InputLayer(3, 24))
 
     def test_add(self):
@@ -72,14 +72,14 @@ class TestNetwork(unittest.TestCase):
         network.set_input_layer(InputLayer(3, 224))
 
         network.add('c1', ConvLayer(3, 64, 224, 3))
-        with self.assertRaisesRegexp(KeyError, 'Network: .*c1.*'):
+        with self.assertRaisesRegex(KeyError, 'Network: .*c1.*'):
             network.add('c1', ConvLayer(64, 128, 224, 3))
 
     def test_add_no_input(self):
         ''' Modifier add no input. '''
         network = Network('test_net')
 
-        with self.assertRaisesRegexp(RuntimeError, 'Network: .*input.*'):
+        with self.assertRaisesRegex(RuntimeError, 'Network: .*input.*'):
             network.add('c1', ConvLayer(3, 64, 224, 3))
 
     def test_add_no_prev(self):
@@ -88,7 +88,7 @@ class TestNetwork(unittest.TestCase):
         network.set_input_layer(InputLayer(3, 224))
 
         network.add('c1', ConvLayer(3, 64, 224, 3))
-        with self.assertRaisesRegexp(KeyError, 'Network: .*prev.*p1.*'):
+        with self.assertRaisesRegex(KeyError, 'Network: .*prev.*p1.*'):
             network.add('p1', PoolingLayer(64, 7, 32), prevs='p1')
 
     def test_add_invalid_type(self):
@@ -96,7 +96,7 @@ class TestNetwork(unittest.TestCase):
         network = Network('test_net')
         network.set_input_layer(InputLayer(3, 224))
 
-        with self.assertRaisesRegexp(TypeError, 'Network: .*Layer.*'):
+        with self.assertRaisesRegex(TypeError, 'Network: .*Layer.*'):
             network.add('c1', (3, 64, 224, 3))
 
     def test_add_unmatch_prev(self):
@@ -105,25 +105,25 @@ class TestNetwork(unittest.TestCase):
         network.set_input_layer(InputLayer(3, 224))
         network.add('c1', ConvLayer(3, 64, 224, 3))
 
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'Network: .*c1.*p1.*mismatch fmap.*'):
             network.add('p1', PoolingLayer(64, 7, 2))
         self.assertEqual(len(network), 1)
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'Network: .*c1.*c2.*mismatch fmap.*'):
             network.add('c2', ConvLayer(64, 128, 220, 3))
         self.assertEqual(len(network), 1)
 
-        with self.assertRaisesRegexp(ValueError, 'Network: .*c1.*prev.*p1.*'):
+        with self.assertRaisesRegex(ValueError, 'Network: .*c1.*prev.*p1.*'):
             network.add('p1', PoolingLayer(32, 7, 32))
         self.assertEqual(len(network), 1)
-        with self.assertRaisesRegexp(ValueError, 'Network: .*c1.*prev.*c2.*'):
+        with self.assertRaisesRegex(ValueError, 'Network: .*c1.*prev.*c2.*'):
             network.add('c2', ConvLayer(32, 128, 224, 3))
         self.assertEqual(len(network), 1)
 
         network.add('c2', ConvLayer(64, 128, 224, 3))
 
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      r'Network: .*c1 | c2.*prev.*p1.*'):
             network.add('p1', PoolingLayer(128, 7, 32), prevs=('c1', 'c2'))
         self.assertEqual(len(network), 2)
@@ -151,16 +151,16 @@ class TestNetwork(unittest.TestCase):
         network = Network('test_net')
 
         network.add_ext('e0', InputLayer(3, 24))
-        with self.assertRaisesRegexp(KeyError, 'Network: .*ext.*'):
+        with self.assertRaisesRegex(KeyError, 'Network: .*ext.*'):
             network.add_ext('e0', InputLayer(3, 24))
 
     def test_add_ext_invalid_type(self):
         ''' Modifier add_ext invalid type. '''
         network = Network('test_net')
 
-        with self.assertRaisesRegexp(TypeError, 'Network: .*external layer.*'):
+        with self.assertRaisesRegex(TypeError, 'Network: .*external layer.*'):
             network.add_ext('e0', Layer(3, 24))
-        with self.assertRaisesRegexp(TypeError, 'Network: .*external layer.*'):
+        with self.assertRaisesRegex(TypeError, 'Network: .*external layer.*'):
             network.add_ext('e0', ConvLayer(3, 8, 24, 3))
 
     def test_prevs(self):
@@ -189,7 +189,7 @@ class TestNetwork(unittest.TestCase):
 
     def test_prevs_input(self):
         ''' Get prevs input layer. '''
-        with self.assertRaisesRegexp(ValueError, 'Network: .*input.*'):
+        with self.assertRaisesRegex(ValueError, 'Network: .*input.*'):
             _ = self.network.prevs(self.network.INPUT_LAYER_KEY)
 
     def test_prevs_ext_next(self):
@@ -205,7 +205,7 @@ class TestNetwork(unittest.TestCase):
     def test_prevs_ext(self):
         ''' Get prevs external layer. '''
         self.network.add_ext('e0', InputLayer(3, 3))
-        with self.assertRaisesRegexp(ValueError, 'Network: .*ext.*'):
+        with self.assertRaisesRegex(ValueError, 'Network: .*ext.*'):
             _ = self.network.prevs('e0')
 
     def test_nexts(self):
@@ -370,7 +370,7 @@ class TestNetwork(unittest.TestCase):
 
     def test_getitem_error(self):
         ''' Accessor getitem. '''
-        with self.assertRaisesRegexp(KeyError, 'Network: .*c2.*'):
+        with self.assertRaisesRegex(KeyError, 'Network: .*c2.*'):
             _ = self.network['c2']
 
     def test_str(self):

--- a/nn_dataflow/tests/unit_test/test_nn_dataflow_scheme.py
+++ b/nn_dataflow/tests/unit_test/test_nn_dataflow_scheme.py
@@ -177,25 +177,25 @@ class TestNNDataflowScheme(unittest.TestCase):
     def test_init_invalid_network(self):
         ''' Invalid network. '''
         with self.assertRaisesRegex(TypeError,
-                                     'NNDataflowScheme: .*network*'):
+                                    'NNDataflowScheme: .*network*'):
             _ = NNDataflowScheme(self.network['c1'], self.input_layout)
 
     def test_init_invalid_input_layout(self):
         ''' Invalid input_layout. '''
         with self.assertRaisesRegex(TypeError,
-                                     'NNDataflowScheme: .*input_layout*'):
+                                    'NNDataflowScheme: .*input_layout*'):
             _ = NNDataflowScheme(self.network, self.input_layout.frngs)
 
     def test_init_invalid_eld_keys(self):
         ''' Invalid ext_layout_dict keys. '''
         with self.assertRaisesRegex(ValueError,
-                                     'NNDataflowScheme: .*ext_layout_dict*'):
+                                    'NNDataflowScheme: .*ext_layout_dict*'):
             _ = NNDataflowScheme(self.network, self.input_layout,
                                  {'e0': self.input_layout})
 
         self.network.add_ext('e0', InputLayer(3, 224))
         with self.assertRaisesRegex(ValueError,
-                                     'NNDataflowScheme: .*ext_layout_dict*'):
+                                    'NNDataflowScheme: .*ext_layout_dict*'):
             _ = NNDataflowScheme(self.network, self.input_layout)
 
     def test_init_invalid_eld_type(self):
@@ -204,7 +204,7 @@ class TestNNDataflowScheme(unittest.TestCase):
         self.network.add_ext('e1', InputLayer(3, 224))
 
         with self.assertRaisesRegex(TypeError,
-                                     'NNDataflowScheme: .*ext_layout*'):
+                                    'NNDataflowScheme: .*ext_layout*'):
             _ = NNDataflowScheme(self.network, self.input_layout,
                                  {'e0': self.input_layout,
                                   'e1': self.input_layout.frngs})
@@ -235,7 +235,7 @@ class TestNNDataflowScheme(unittest.TestCase):
         df = NNDataflowScheme(self.network, self.input_layout)
 
         with self.assertRaisesRegex(TypeError,
-                                     'NNDataflowScheme: .*SchedulingResult*'):
+                                    'NNDataflowScheme: .*SchedulingResult*'):
             df['c1'] = self.c1res.scheme
 
     def test_setitem_already_exists(self):
@@ -271,7 +271,7 @@ class TestNNDataflowScheme(unittest.TestCase):
         df = NNDataflowScheme(self.network, self.input_layout)
 
         with self.assertRaisesRegex(ValueError,
-                                     'NNDataflowScheme: .*segment index*'):
+                                    'NNDataflowScheme: .*segment index*'):
             df['c1'] = self.c1res._replace(sched_seq=(1, 0, 0))
 
         df = NNDataflowScheme(self.network, self.input_layout)
@@ -279,7 +279,7 @@ class TestNNDataflowScheme(unittest.TestCase):
         df['p1'] = self.p1res._replace(sched_seq=(1, 0, 0))
 
         with self.assertRaisesRegex(ValueError,
-                                     'NNDataflowScheme: .*segment index*'):
+                                    'NNDataflowScheme: .*segment index*'):
             df['p2'] = self.p2res._replace(sched_seq=(0, 0, 0))
 
     def test_delitem(self):
@@ -294,7 +294,7 @@ class TestNNDataflowScheme(unittest.TestCase):
         ''' __iter__ and __len__. '''
         self.assertEqual(len(self.dtfl), 3)
 
-        lst = [l for l in self.dtfl]
+        lst = [l for l in self.dtfl]  # pylint: disable=unnecessary-comprehension
         self.assertIn('c1', lst)
         self.assertIn('p1', lst)
         self.assertIn('p2', lst)
@@ -491,6 +491,6 @@ class TestNNDataflowScheme(unittest.TestCase):
     def test_stats_not_supported(self):
         ''' Per-layer stats: not supported. '''
         with self.assertRaisesRegex(AttributeError,
-                                     'NNDataflowScheme: .*not_supported.*'):
+                                    'NNDataflowScheme: .*not_supported.*'):
             _ = self.dtfl.perlayer_stats('not_supported')
 

--- a/nn_dataflow/tests/unit_test/test_nn_dataflow_scheme.py
+++ b/nn_dataflow/tests/unit_test/test_nn_dataflow_scheme.py
@@ -176,25 +176,25 @@ class TestNNDataflowScheme(unittest.TestCase):
 
     def test_init_invalid_network(self):
         ''' Invalid network. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'NNDataflowScheme: .*network*'):
             _ = NNDataflowScheme(self.network['c1'], self.input_layout)
 
     def test_init_invalid_input_layout(self):
         ''' Invalid input_layout. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'NNDataflowScheme: .*input_layout*'):
             _ = NNDataflowScheme(self.network, self.input_layout.frngs)
 
     def test_init_invalid_eld_keys(self):
         ''' Invalid ext_layout_dict keys. '''
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'NNDataflowScheme: .*ext_layout_dict*'):
             _ = NNDataflowScheme(self.network, self.input_layout,
                                  {'e0': self.input_layout})
 
         self.network.add_ext('e0', InputLayer(3, 224))
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'NNDataflowScheme: .*ext_layout_dict*'):
             _ = NNDataflowScheme(self.network, self.input_layout)
 
@@ -203,7 +203,7 @@ class TestNNDataflowScheme(unittest.TestCase):
         self.network.add_ext('e0', InputLayer(3, 224))
         self.network.add_ext('e1', InputLayer(3, 224))
 
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'NNDataflowScheme: .*ext_layout*'):
             _ = NNDataflowScheme(self.network, self.input_layout,
                                  {'e0': self.input_layout,
@@ -227,14 +227,14 @@ class TestNNDataflowScheme(unittest.TestCase):
         ''' __setitem__ not in network. '''
         df = NNDataflowScheme(self.network, self.input_layout)
 
-        with self.assertRaisesRegexp(KeyError, 'NNDataflowScheme: .*cc.*'):
+        with self.assertRaisesRegex(KeyError, 'NNDataflowScheme: .*cc.*'):
             df['cc'] = self.c1res
 
     def test_setitem_invalid_value(self):
         ''' __setitem__ invalid value. '''
         df = NNDataflowScheme(self.network, self.input_layout)
 
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'NNDataflowScheme: .*SchedulingResult*'):
             df['c1'] = self.c1res.scheme
 
@@ -243,14 +243,14 @@ class TestNNDataflowScheme(unittest.TestCase):
         df = NNDataflowScheme(self.network, self.input_layout)
         df['c1'] = self.c1res
 
-        with self.assertRaisesRegexp(KeyError, 'NNDataflowScheme: .*c1*'):
+        with self.assertRaisesRegex(KeyError, 'NNDataflowScheme: .*c1*'):
             df['c1'] = self.c1res._replace(sched_seq=(1, 0, 0))
 
     def test_setitem_prev_not_in(self):
         ''' __setitem__ previous not existing. '''
         df = NNDataflowScheme(self.network, self.input_layout)
 
-        with self.assertRaisesRegexp(KeyError, 'NNDataflowScheme: .*p1*'):
+        with self.assertRaisesRegex(KeyError, 'NNDataflowScheme: .*p1*'):
             df['p1'] = self.p1res
 
     def test_setitem_prev_input_ext(self):
@@ -270,7 +270,7 @@ class TestNNDataflowScheme(unittest.TestCase):
         ''' __setitem__ invalid segment index. '''
         df = NNDataflowScheme(self.network, self.input_layout)
 
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'NNDataflowScheme: .*segment index*'):
             df['c1'] = self.c1res._replace(sched_seq=(1, 0, 0))
 
@@ -278,7 +278,7 @@ class TestNNDataflowScheme(unittest.TestCase):
         df['c1'] = self.c1res
         df['p1'] = self.p1res._replace(sched_seq=(1, 0, 0))
 
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'NNDataflowScheme: .*segment index*'):
             df['p2'] = self.p2res._replace(sched_seq=(0, 0, 0))
 
@@ -287,7 +287,7 @@ class TestNNDataflowScheme(unittest.TestCase):
         df = NNDataflowScheme(self.network, self.input_layout)
         df['c1'] = self.c1res
 
-        with self.assertRaisesRegexp(KeyError, 'NNDataflowScheme: .*'):
+        with self.assertRaisesRegex(KeyError, 'NNDataflowScheme: .*'):
             del df['c1']
 
     def test_iter_len(self):
@@ -490,7 +490,7 @@ class TestNNDataflowScheme(unittest.TestCase):
 
     def test_stats_not_supported(self):
         ''' Per-layer stats: not supported. '''
-        with self.assertRaisesRegexp(AttributeError,
+        with self.assertRaisesRegex(AttributeError,
                                      'NNDataflowScheme: .*not_supported.*'):
             _ = self.dtfl.perlayer_stats('not_supported')
 

--- a/nn_dataflow/tests/unit_test/test_node_region.py
+++ b/nn_dataflow/tests/unit_test/test_node_region.py
@@ -88,21 +88,21 @@ class TestNodeRegion(unittest.TestCase):
 
     def test_invalid_dim(self):
         ''' Invalid dim. '''
-        with self.assertRaisesRegexp(TypeError, 'NodeRegion: .*dim.*'):
+        with self.assertRaisesRegex(TypeError, 'NodeRegion: .*dim.*'):
             _ = NodeRegion(dim=(4, 4),
                            origin=PhyDim2(1, 3),
                            type=NodeRegion.PROC)
 
     def test_invalid_origin(self):
         ''' Invalid origin. '''
-        with self.assertRaisesRegexp(TypeError, 'NodeRegion: .*origin.*'):
+        with self.assertRaisesRegex(TypeError, 'NodeRegion: .*origin.*'):
             _ = NodeRegion(dim=PhyDim2(4, 4),
                            origin=(1, 3),
                            type=NodeRegion.PROC)
 
     def test_invalid_dist(self):
         ''' Invalid dist. '''
-        with self.assertRaisesRegexp(TypeError, 'NodeRegion: .*dist.*'):
+        with self.assertRaisesRegex(TypeError, 'NodeRegion: .*dist.*'):
             _ = NodeRegion(dim=PhyDim2(4, 4),
                            origin=PhyDim2(1, 3),
                            dist=(1, 1),
@@ -110,14 +110,14 @@ class TestNodeRegion(unittest.TestCase):
 
     def test_invalid_type(self):
         ''' Invalid type. '''
-        with self.assertRaisesRegexp(ValueError, 'NodeRegion: .*type.*'):
+        with self.assertRaisesRegex(ValueError, 'NodeRegion: .*type.*'):
             _ = NodeRegion(dim=PhyDim2(4, 4),
                            origin=PhyDim2(1, 3),
                            type=NodeRegion.NUM)
 
     def test_invalid_wtot_type(self):
         ''' Invalid wtot type. '''
-        with self.assertRaisesRegexp(TypeError, 'NodeRegion: .*wtot.*'):
+        with self.assertRaisesRegex(TypeError, 'NodeRegion: .*wtot.*'):
             _ = NodeRegion(dim=PhyDim2(4, 4),
                            origin=PhyDim2(1, 3),
                            type=NodeRegion.PROC,
@@ -125,7 +125,7 @@ class TestNodeRegion(unittest.TestCase):
 
     def test_invalid_wbeg_type(self):
         ''' Invalid wbeg type. '''
-        with self.assertRaisesRegexp(TypeError, 'NodeRegion: .*wbeg.*'):
+        with self.assertRaisesRegex(TypeError, 'NodeRegion: .*wbeg.*'):
             _ = NodeRegion(dim=PhyDim2(4, 4),
                            origin=PhyDim2(1, 3),
                            type=NodeRegion.PROC,
@@ -133,21 +133,21 @@ class TestNodeRegion(unittest.TestCase):
 
     def test_invalid_wbeg(self):
         ''' Invalid wbeg. '''
-        with self.assertRaisesRegexp(ValueError, 'NodeRegion: .*wbeg.*'):
+        with self.assertRaisesRegex(ValueError, 'NodeRegion: .*wbeg.*'):
             _ = NodeRegion(dim=PhyDim2(4, 4),
                            origin=PhyDim2(1, 3),
                            type=NodeRegion.PROC,
                            wtot=4,
                            wbeg=5)
 
-        with self.assertRaisesRegexp(ValueError, 'NodeRegion: .*wbeg.*'):
+        with self.assertRaisesRegex(ValueError, 'NodeRegion: .*wbeg.*'):
             _ = NodeRegion(dim=PhyDim2(4, 4),
                            origin=PhyDim2(1, 3),
                            type=NodeRegion.PROC,
                            wtot=4,
                            wbeg=-5)
 
-        with self.assertRaisesRegexp(ValueError, 'NodeRegion: .*wbeg.*'):
+        with self.assertRaisesRegex(ValueError, 'NodeRegion: .*wbeg.*'):
             _ = NodeRegion(dim=PhyDim2(4, 4),
                            origin=PhyDim2(1, 3),
                            type=NodeRegion.PROC,
@@ -215,10 +215,10 @@ class TestNodeRegion(unittest.TestCase):
                         origin=PhyDim2(1, 3),
                         type=NodeRegion.PROC)
 
-        with self.assertRaisesRegexp(TypeError, 'NodeRegion: .*PhyDim2.*'):
+        with self.assertRaisesRegex(TypeError, 'NodeRegion: .*PhyDim2.*'):
             _ = nr.rel2abs((0, 0))
 
-        with self.assertRaisesRegexp(TypeError, 'NodeRegion: .*PhyDim2.*'):
+        with self.assertRaisesRegex(TypeError, 'NodeRegion: .*PhyDim2.*'):
             _ = nr.rel2abs(1)
 
     def test_rel2abs_not_in(self):
@@ -227,10 +227,10 @@ class TestNodeRegion(unittest.TestCase):
                         origin=PhyDim2(1, 3),
                         type=NodeRegion.PROC)
 
-        with self.assertRaisesRegexp(ValueError, 'NodeRegion: .*not in.*'):
+        with self.assertRaisesRegex(ValueError, 'NodeRegion: .*not in.*'):
             _ = nr.rel2abs(PhyDim2(-1, 0))
 
-        with self.assertRaisesRegexp(ValueError, 'NodeRegion: .*not in.*'):
+        with self.assertRaisesRegex(ValueError, 'NodeRegion: .*not in.*'):
             _ = nr.rel2abs(PhyDim2(0, 4))
 
     def test_rel2abs_folded(self):

--- a/nn_dataflow/tests/unit_test/test_option.py
+++ b/nn_dataflow/tests/unit_test/test_option.py
@@ -79,86 +79,86 @@ class TestOption(unittest.TestCase):
 
     def test_invalid_args(self):
         ''' Invalid args. '''
-        with self.assertRaisesRegexp(TypeError, 'Option: .*at most.*100'):
+        with self.assertRaisesRegex(TypeError, 'Option: .*at most.*100'):
             _ = Option(*[None] * 100)
 
     def test_invalid_kwargs(self):
         ''' Invalid kwargs. '''
-        with self.assertRaisesRegexp(TypeError, 'Option: .*bad.*'):
+        with self.assertRaisesRegex(TypeError, 'Option: .*bad.*'):
             _ = Option(bad='')
 
     def test_invalid_both_args_kwargs(self):
         ''' Invalid both args and kwargs are given. '''
-        with self.assertRaisesRegexp(TypeError, 'Option: .*sw_gbuf_bypass.*'):
+        with self.assertRaisesRegex(TypeError, 'Option: .*sw_gbuf_bypass.*'):
             _ = Option((False,) * 3, sw_gbuf_bypass=(False,) * 3)
 
     def test_invalid_swgbyp_type(self):
         ''' Invalid sw_gbuf_bypass type. '''
-        with self.assertRaisesRegexp(TypeError, 'Option: .*sw_gbuf_bypass.*'):
+        with self.assertRaisesRegex(TypeError, 'Option: .*sw_gbuf_bypass.*'):
             _ = Option(sw_gbuf_bypass=[False, False, False])
 
     def test_invalid_swgbyp_len(self):
         ''' Invalid sw_gbuf_bypass len. '''
-        with self.assertRaisesRegexp(ValueError, 'Option: .*sw_gbuf_bypass.*'):
+        with self.assertRaisesRegex(ValueError, 'Option: .*sw_gbuf_bypass.*'):
             _ = Option(sw_gbuf_bypass=(False, False))
 
     def test_invalid_swsol_hwbufshr(self):
         ''' Invalid sw_solve_loopblocking and hw_gbuf_sharing comb. '''
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'Option: .*sw_solve_loopblocking.*'
                                      'hw_gbuf_sharing.*'):
             _ = Option(sw_solve_loopblocking=True, hw_gbuf_sharing=True)
 
     def test_invalid_hwaccfwd_hwbufshr(self):
         ''' Invalid hw_access_forwarding and hw_gbuf_sharing comb. '''
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'Option: .*hw_access_forwarding.*'
                                      'hw_gbuf_sharing.*'):
             _ = Option(hw_access_forwarding=True, hw_gbuf_sharing=True)
 
     def test_invalid_swsol_hwswb(self):
         ''' Invalid sw_solve_loopblocking and hw_gbuf_save_writeback comb. '''
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'Option: .*sw_solve_loopblocking.*'
                                      'hw_gbuf_save_writeback.*'):
             _ = Option(sw_solve_loopblocking=True, hw_gbuf_save_writeback=True)
 
     def test_invalid_part_hybrid_ifmaps(self):
         ''' Invalid partition_hybrid and partition_ifmaps comb. '''
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'Option: .*partition_ifmaps.*'
                                      'partition_hybrid.*'):
             _ = Option(partition_hybrid=False, partition_ifmaps=True)
 
     def test_invalid_time_ovhd(self):
         ''' Invalid layer_pipeline_time_ovhd. '''
-        with self.assertRaisesRegexp(KeyError,
+        with self.assertRaisesRegex(KeyError,
                                      'Option: .*layer_pipeline_time_ovhd.*'):
             _ = Option(layer_pipeline_time_ovhd=None)
 
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'Option: .*layer_pipeline_time_ovhd.*'):
             _ = Option(layer_pipeline_time_ovhd=-1)
 
     def test_invalid_max_degree(self):
         ''' Invalid layer_pipeline_max_degree. '''
-        with self.assertRaisesRegexp(KeyError,
+        with self.assertRaisesRegex(KeyError,
                                      'Option: .*layer_pipeline_max_degree.*'):
             _ = Option(layer_pipeline_max_degree=None)
 
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'Option: .*layer_pipeline_max_degree.*'):
             _ = Option(layer_pipeline_max_degree=-1)
 
     def test_invalid_opt_goal(self):
         ''' Invalid opt_goal. '''
-        with self.assertRaisesRegexp(ValueError, 'Option: .*opt_goal.*'):
+        with self.assertRaisesRegex(ValueError, 'Option: .*opt_goal.*'):
             _ = Option(opt_goal='o')
-        with self.assertRaisesRegexp(ValueError, 'Option: .*opt_goal.*'):
+        with self.assertRaisesRegex(ValueError, 'Option: .*opt_goal.*'):
             _ = Option(opt_goal='E')
 
     def test_option_list(self):
         ''' Accessor option_list. '''
         options = Option()
-        self.assertItemsEqual(options.option_list(), options._fields)
+        self.assertCountEqual(options.option_list(), options._fields)
 

--- a/nn_dataflow/tests/unit_test/test_option.py
+++ b/nn_dataflow/tests/unit_test/test_option.py
@@ -105,49 +105,49 @@ class TestOption(unittest.TestCase):
     def test_invalid_swsol_hwbufshr(self):
         ''' Invalid sw_solve_loopblocking and hw_gbuf_sharing comb. '''
         with self.assertRaisesRegex(ValueError,
-                                     'Option: .*sw_solve_loopblocking.*'
-                                     'hw_gbuf_sharing.*'):
+                                    'Option: .*sw_solve_loopblocking.*'
+                                    'hw_gbuf_sharing.*'):
             _ = Option(sw_solve_loopblocking=True, hw_gbuf_sharing=True)
 
     def test_invalid_hwaccfwd_hwbufshr(self):
         ''' Invalid hw_access_forwarding and hw_gbuf_sharing comb. '''
         with self.assertRaisesRegex(ValueError,
-                                     'Option: .*hw_access_forwarding.*'
-                                     'hw_gbuf_sharing.*'):
+                                    'Option: .*hw_access_forwarding.*'
+                                    'hw_gbuf_sharing.*'):
             _ = Option(hw_access_forwarding=True, hw_gbuf_sharing=True)
 
     def test_invalid_swsol_hwswb(self):
         ''' Invalid sw_solve_loopblocking and hw_gbuf_save_writeback comb. '''
         with self.assertRaisesRegex(ValueError,
-                                     'Option: .*sw_solve_loopblocking.*'
-                                     'hw_gbuf_save_writeback.*'):
+                                    'Option: .*sw_solve_loopblocking.*'
+                                    'hw_gbuf_save_writeback.*'):
             _ = Option(sw_solve_loopblocking=True, hw_gbuf_save_writeback=True)
 
     def test_invalid_part_hybrid_ifmaps(self):
         ''' Invalid partition_hybrid and partition_ifmaps comb. '''
         with self.assertRaisesRegex(ValueError,
-                                     'Option: .*partition_ifmaps.*'
-                                     'partition_hybrid.*'):
+                                    'Option: .*partition_ifmaps.*'
+                                    'partition_hybrid.*'):
             _ = Option(partition_hybrid=False, partition_ifmaps=True)
 
     def test_invalid_time_ovhd(self):
         ''' Invalid layer_pipeline_time_ovhd. '''
         with self.assertRaisesRegex(KeyError,
-                                     'Option: .*layer_pipeline_time_ovhd.*'):
+                                    'Option: .*layer_pipeline_time_ovhd.*'):
             _ = Option(layer_pipeline_time_ovhd=None)
 
         with self.assertRaisesRegex(ValueError,
-                                     'Option: .*layer_pipeline_time_ovhd.*'):
+                                    'Option: .*layer_pipeline_time_ovhd.*'):
             _ = Option(layer_pipeline_time_ovhd=-1)
 
     def test_invalid_max_degree(self):
         ''' Invalid layer_pipeline_max_degree. '''
         with self.assertRaisesRegex(KeyError,
-                                     'Option: .*layer_pipeline_max_degree.*'):
+                                    'Option: .*layer_pipeline_max_degree.*'):
             _ = Option(layer_pipeline_max_degree=None)
 
         with self.assertRaisesRegex(ValueError,
-                                     'Option: .*layer_pipeline_max_degree.*'):
+                                    'Option: .*layer_pipeline_max_degree.*'):
             _ = Option(layer_pipeline_max_degree=-1)
 
     def test_invalid_opt_goal(self):

--- a/nn_dataflow/tests/unit_test/test_partition_scheme.py
+++ b/nn_dataflow/tests/unit_test/test_partition_scheme.py
@@ -31,7 +31,7 @@ class TestPartitionScheme(unittest.TestCase):
     def setUp(self):
         self.ps1 = PartitionScheme(order=[pe.BATP, pe.OUTP, pe.OFMP, pe.INPP],
                                    pdims=[(2, 3), (3, 1), (1, 5), (5, 2)])
-        self.ps2 = PartitionScheme(order=range(pe.NUM),
+        self.ps2 = PartitionScheme(order=list(range(pe.NUM)),
                                    pdims=[(2, 2), (5, 5), (3, 3), (1, 1)])
 
         self.nr1 = NodeRegion(origin=PhyDim2(0, 0), dim=self.ps1.dim(),
@@ -41,30 +41,30 @@ class TestPartitionScheme(unittest.TestCase):
 
     def test_invalid_order(self):
         ''' Invalid order. '''
-        with self.assertRaisesRegexp(ValueError, 'PartitionScheme: .*order.*'):
-            _ = PartitionScheme(order=range(pe.NUM - 1),
+        with self.assertRaisesRegex(ValueError, 'PartitionScheme: .*order.*'):
+            _ = PartitionScheme(order=list(range(pe.NUM - 1)),
                                 pdims=[(1, 1)] * pe.NUM)
 
-        with self.assertRaisesRegexp(ValueError, 'PartitionScheme: .*order.*'):
-            _ = PartitionScheme(order=[0] + range(2, pe.NUM),
+        with self.assertRaisesRegex(ValueError, 'PartitionScheme: .*order.*'):
+            _ = PartitionScheme(order=[0] + list(range(2, pe.NUM)),
                                 pdims=[(1, 1)] * pe.NUM)
 
-        with self.assertRaisesRegexp(ValueError, 'PartitionScheme: .*order.*'):
-            _ = PartitionScheme(order=[1] + range(pe.NUM),
+        with self.assertRaisesRegex(ValueError, 'PartitionScheme: .*order.*'):
+            _ = PartitionScheme(order=[1] + list(range(pe.NUM)),
                                 pdims=[(1, 1)] * pe.NUM)
 
-        with self.assertRaisesRegexp(ValueError, 'PartitionScheme: .*order.*'):
-            _ = PartitionScheme(order=range(4, 4 + pe.NUM),
+        with self.assertRaisesRegex(ValueError, 'PartitionScheme: .*order.*'):
+            _ = PartitionScheme(order=list(range(4, 4 + pe.NUM)),
                                 pdims=[(1, 1)] * pe.NUM)
 
     def test_invalid_pdims(self):
         ''' Invalid pdims. '''
-        with self.assertRaisesRegexp(ValueError, 'PartitionScheme: .*pdims.*'):
-            _ = PartitionScheme(order=range(pe.NUM),
+        with self.assertRaisesRegex(ValueError, 'PartitionScheme: .*pdims.*'):
+            _ = PartitionScheme(order=list(range(pe.NUM)),
                                 pdims=[(1, 1)] * (pe.NUM - 1))
 
-        with self.assertRaisesRegexp(ValueError, 'PartitionScheme: .*pdims.*'):
-            _ = PartitionScheme(order=range(pe.NUM),
+        with self.assertRaisesRegex(ValueError, 'PartitionScheme: .*pdims.*'):
+            _ = PartitionScheme(order=list(range(pe.NUM)),
                                 pdims=[(1, 1), (1, 1), (2, 1, 1), (1, 1)])
 
     def test_dim(self):
@@ -226,7 +226,7 @@ class TestPartitionScheme(unittest.TestCase):
 
     def test_part_layer_invalid_inpart(self):
         ''' Get part_layer invalid INPP. '''
-        with self.assertRaisesRegexp(ValueError, 'PartitionScheme: .*input.*'):
+        with self.assertRaisesRegex(ValueError, 'PartitionScheme: .*input.*'):
             _ = self.ps1.part_layer(PoolingLayer(self.ps1.size(pe.OUTP),
                                                  self.ps1.size(pe.OFMP), 2),
                                     self.ps1.size(pe.BATP))
@@ -246,7 +246,7 @@ class TestPartitionScheme(unittest.TestCase):
         self.assertEqual(layer.total_ops(), 0)
         self.assertIsNone(_Layer.data_loops())
 
-        with self.assertRaisesRegexp(TypeError, 'PartitionScheme: .*layer.*'):
+        with self.assertRaisesRegex(TypeError, 'PartitionScheme: .*layer.*'):
             _ = self.ps1.part_layer(layer, self.ps1.size(pe.BATP))
 
     def test_part_neighbor_dist(self):
@@ -377,7 +377,7 @@ class TestPartitionScheme(unittest.TestCase):
 
     def test_projection_empty_region(self):
         ''' Get projection with empty region. '''
-        with self.assertRaisesRegexp(ValueError, 'PartitionScheme: .*region.*'):
+        with self.assertRaisesRegex(ValueError, 'PartitionScheme: .*region.*'):
             _ = self.ps1.projection(NodeRegion(origin=PhyDim2(0, 0),
                                                dim=PhyDim2(0, 0),
                                                type=NodeRegion.DRAM))

--- a/nn_dataflow/tests/unit_test/test_phy_dim2.py
+++ b/nn_dataflow/tests/unit_test/test_phy_dim2.py
@@ -70,6 +70,6 @@ class TestPhyDim2(unittest.TestCase):
     def test_hop_dist_error(self):
         ''' Get hop distance. '''
         dim1 = PhyDim2(14, 12)
-        with self.assertRaisesRegexp(TypeError, 'hop_dist'):
+        with self.assertRaisesRegex(TypeError, 'hop_dist'):
             _ = dim1.hop_dist((5, 20))
 

--- a/nn_dataflow/tests/unit_test/test_resource.py
+++ b/nn_dataflow/tests/unit_test/test_resource.py
@@ -58,7 +58,7 @@ class TestResource(unittest.TestCase):
 
     def test_invalid_proc_region(self):
         ''' Invalid proc_region. '''
-        with self.assertRaisesRegexp(TypeError, 'Resource: .*proc_region.*'):
+        with self.assertRaisesRegex(TypeError, 'Resource: .*proc_region.*'):
             _ = Resource(proc_region=PhyDim2(2, 2),
                          dram_region=self.dram_region,
                          src_data_region=self.src_data_region,
@@ -73,7 +73,7 @@ class TestResource(unittest.TestCase):
 
     def test_invalid_proc_region_dram(self):
         ''' Invalid proc_region with type DRAM. '''
-        with self.assertRaisesRegexp(ValueError, 'Resource: .*proc_.*type.*'):
+        with self.assertRaisesRegex(ValueError, 'Resource: .*proc_.*type.*'):
             _ = Resource(proc_region=NodeRegion(dim=PhyDim2(2, 2),
                                                 origin=PhyDim2(0, 0),
                                                 type=NodeRegion.DRAM),
@@ -90,7 +90,7 @@ class TestResource(unittest.TestCase):
 
     def test_invalid_dram_region(self):
         ''' Invalid dram_region. '''
-        with self.assertRaisesRegexp(TypeError, 'Resource: .*dram_region.*'):
+        with self.assertRaisesRegex(TypeError, 'Resource: .*dram_region.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=PhyDim2(2, 2),
                          src_data_region=self.src_data_region,
@@ -105,7 +105,7 @@ class TestResource(unittest.TestCase):
 
     def test_invalid_dram_region_proc(self):
         ''' Invalid dram_region with type DRAM. '''
-        with self.assertRaisesRegexp(ValueError, 'Resource: .*dram_.*type.*'):
+        with self.assertRaisesRegex(ValueError, 'Resource: .*dram_.*type.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=NodeRegion(dim=PhyDim2(2, 2),
                                                 origin=PhyDim2(0, 0),
@@ -122,7 +122,7 @@ class TestResource(unittest.TestCase):
 
     def test_invalid_data_region(self):
         ''' Invalid src/dst_proc_region. '''
-        with self.assertRaisesRegexp(TypeError, 'Resource: .*src_data_.*'):
+        with self.assertRaisesRegex(TypeError, 'Resource: .*src_data_.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
                          src_data_region=PhyDim2(2, 1),
@@ -134,7 +134,7 @@ class TestResource(unittest.TestCase):
                          dram_bandwidth=128,
                          no_time_mux=False,
                         )
-        with self.assertRaisesRegexp(TypeError, 'Resource: .*dst_data_.*'):
+        with self.assertRaisesRegex(TypeError, 'Resource: .*dst_data_.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
                          src_data_region=self.src_data_region,
@@ -149,7 +149,7 @@ class TestResource(unittest.TestCase):
 
     def test_invalid_dim_array(self):
         ''' Invalid dim_array. '''
-        with self.assertRaisesRegexp(TypeError, 'Resource: .*dim_array.*'):
+        with self.assertRaisesRegex(TypeError, 'Resource: .*dim_array.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
                          src_data_region=self.src_data_region,
@@ -164,7 +164,7 @@ class TestResource(unittest.TestCase):
 
     def test_invalid_size_gbuf(self):
         ''' Invalid size_gbuf. '''
-        with self.assertRaisesRegexp(TypeError, 'Resource: .*size_gbuf.*'):
+        with self.assertRaisesRegex(TypeError, 'Resource: .*size_gbuf.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
                          src_data_region=self.src_data_region,
@@ -179,7 +179,7 @@ class TestResource(unittest.TestCase):
 
     def test_invalid_size_regf(self):
         ''' Invalid size_regf. '''
-        with self.assertRaisesRegexp(TypeError, 'Resource: .*size_regf.*'):
+        with self.assertRaisesRegex(TypeError, 'Resource: .*size_regf.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
                          src_data_region=self.src_data_region,
@@ -194,7 +194,7 @@ class TestResource(unittest.TestCase):
 
     def test_invalid_array_bus_width(self):
         ''' Invalid array_bus_width. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'Resource: .*array_bus_width.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
@@ -207,7 +207,7 @@ class TestResource(unittest.TestCase):
                          dram_bandwidth=128,
                          no_time_mux=False,
                         )
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'Resource: .*array_bus_width.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
@@ -220,7 +220,7 @@ class TestResource(unittest.TestCase):
                          dram_bandwidth=128,
                          no_time_mux=False,
                         )
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'Resource: .*array_bus_width.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
@@ -236,7 +236,7 @@ class TestResource(unittest.TestCase):
 
     def test_invalid_dram_bandwidth(self):
         ''' Invalid dram_bandwidth. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'Resource: .*dram_bandwidth.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
@@ -249,7 +249,7 @@ class TestResource(unittest.TestCase):
                          dram_bandwidth=None,
                          no_time_mux=False,
                         )
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'Resource: .*dram_bandwidth.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
@@ -262,7 +262,7 @@ class TestResource(unittest.TestCase):
                          dram_bandwidth=-3,
                          no_time_mux=False,
                         )
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'Resource: .*dram_bandwidth.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
@@ -278,7 +278,7 @@ class TestResource(unittest.TestCase):
 
     def test_invalid_no_time_mux(self):
         ''' Invalid no_time_mux. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'Resource: .*no_time_mux.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,

--- a/nn_dataflow/tests/unit_test/test_resource.py
+++ b/nn_dataflow/tests/unit_test/test_resource.py
@@ -195,7 +195,7 @@ class TestResource(unittest.TestCase):
     def test_invalid_array_bus_width(self):
         ''' Invalid array_bus_width. '''
         with self.assertRaisesRegex(TypeError,
-                                     'Resource: .*array_bus_width.*'):
+                                    'Resource: .*array_bus_width.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
                          src_data_region=self.src_data_region,
@@ -208,7 +208,7 @@ class TestResource(unittest.TestCase):
                          no_time_mux=False,
                         )
         with self.assertRaisesRegex(ValueError,
-                                     'Resource: .*array_bus_width.*'):
+                                    'Resource: .*array_bus_width.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
                          src_data_region=self.src_data_region,
@@ -221,7 +221,7 @@ class TestResource(unittest.TestCase):
                          no_time_mux=False,
                         )
         with self.assertRaisesRegex(ValueError,
-                                     'Resource: .*array_bus_width.*'):
+                                    'Resource: .*array_bus_width.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
                          src_data_region=self.src_data_region,
@@ -237,7 +237,7 @@ class TestResource(unittest.TestCase):
     def test_invalid_dram_bandwidth(self):
         ''' Invalid dram_bandwidth. '''
         with self.assertRaisesRegex(TypeError,
-                                     'Resource: .*dram_bandwidth.*'):
+                                    'Resource: .*dram_bandwidth.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
                          src_data_region=self.src_data_region,
@@ -250,7 +250,7 @@ class TestResource(unittest.TestCase):
                          no_time_mux=False,
                         )
         with self.assertRaisesRegex(ValueError,
-                                     'Resource: .*dram_bandwidth.*'):
+                                    'Resource: .*dram_bandwidth.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
                          src_data_region=self.src_data_region,
@@ -263,7 +263,7 @@ class TestResource(unittest.TestCase):
                          no_time_mux=False,
                         )
         with self.assertRaisesRegex(ValueError,
-                                     'Resource: .*dram_bandwidth.*'):
+                                    'Resource: .*dram_bandwidth.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
                          src_data_region=self.src_data_region,
@@ -279,7 +279,7 @@ class TestResource(unittest.TestCase):
     def test_invalid_no_time_mux(self):
         ''' Invalid no_time_mux. '''
         with self.assertRaisesRegex(TypeError,
-                                     'Resource: .*no_time_mux.*'):
+                                    'Resource: .*no_time_mux.*'):
             _ = Resource(proc_region=self.proc_region,
                          dram_region=self.dram_region,
                          src_data_region=self.src_data_region,

--- a/nn_dataflow/tests/unit_test/test_scheduling_condition.py
+++ b/nn_dataflow/tests/unit_test/test_scheduling_condition.py
@@ -66,7 +66,7 @@ class TestSchedulingCondition(unittest.TestCase):
 
     def test_invalid_resource(self):
         ''' Invalid resource. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'SchedulingCondition: .*resource.*'):
             _ = SchedulingCondition(resource=None,
                                     constraint=self.none_cstr,
@@ -75,7 +75,7 @@ class TestSchedulingCondition(unittest.TestCase):
 
     def test_invalid_constraint(self):
         ''' Invalid constraint. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'SchedulingCondition: .*constraint.*'):
             _ = SchedulingCondition(resource=self.resource,
                                     constraint=None,
@@ -84,7 +84,7 @@ class TestSchedulingCondition(unittest.TestCase):
 
     def test_invalid_ifmap_layout(self):
         ''' Invalid ifmap_layout. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'SchedulingCondition: .*ifmap_layout.*'):
             _ = SchedulingCondition(resource=self.resource,
                                     constraint=self.none_cstr,
@@ -93,14 +93,14 @@ class TestSchedulingCondition(unittest.TestCase):
 
     def test_invalid_sched_seq(self):
         ''' Invalid sched_seq. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'SchedulingCondition: .*sched_seq.*'):
             _ = SchedulingCondition(resource=self.resource,
                                     constraint=self.none_cstr,
                                     ifmap_layout=self.ifmap_layout,
                                     sched_seq=list(self.sched_seq))
 
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'SchedulingCondition: .*sched_seq.*'):
             _ = SchedulingCondition(resource=self.resource,
                                     constraint=self.none_cstr,

--- a/nn_dataflow/tests/unit_test/test_scheduling_condition.py
+++ b/nn_dataflow/tests/unit_test/test_scheduling_condition.py
@@ -67,7 +67,7 @@ class TestSchedulingCondition(unittest.TestCase):
     def test_invalid_resource(self):
         ''' Invalid resource. '''
         with self.assertRaisesRegex(TypeError,
-                                     'SchedulingCondition: .*resource.*'):
+                                    'SchedulingCondition: .*resource.*'):
             _ = SchedulingCondition(resource=None,
                                     constraint=self.none_cstr,
                                     ifmap_layout=self.ifmap_layout,
@@ -76,7 +76,7 @@ class TestSchedulingCondition(unittest.TestCase):
     def test_invalid_constraint(self):
         ''' Invalid constraint. '''
         with self.assertRaisesRegex(TypeError,
-                                     'SchedulingCondition: .*constraint.*'):
+                                    'SchedulingCondition: .*constraint.*'):
             _ = SchedulingCondition(resource=self.resource,
                                     constraint=None,
                                     ifmap_layout=self.ifmap_layout,
@@ -85,7 +85,7 @@ class TestSchedulingCondition(unittest.TestCase):
     def test_invalid_ifmap_layout(self):
         ''' Invalid ifmap_layout. '''
         with self.assertRaisesRegex(TypeError,
-                                     'SchedulingCondition: .*ifmap_layout.*'):
+                                    'SchedulingCondition: .*ifmap_layout.*'):
             _ = SchedulingCondition(resource=self.resource,
                                     constraint=self.none_cstr,
                                     ifmap_layout=None,
@@ -94,14 +94,14 @@ class TestSchedulingCondition(unittest.TestCase):
     def test_invalid_sched_seq(self):
         ''' Invalid sched_seq. '''
         with self.assertRaisesRegex(TypeError,
-                                     'SchedulingCondition: .*sched_seq.*'):
+                                    'SchedulingCondition: .*sched_seq.*'):
             _ = SchedulingCondition(resource=self.resource,
                                     constraint=self.none_cstr,
                                     ifmap_layout=self.ifmap_layout,
                                     sched_seq=list(self.sched_seq))
 
         with self.assertRaisesRegex(ValueError,
-                                     'SchedulingCondition: .*sched_seq.*'):
+                                    'SchedulingCondition: .*sched_seq.*'):
             _ = SchedulingCondition(resource=self.resource,
                                     constraint=self.none_cstr,
                                     ifmap_layout=self.ifmap_layout,

--- a/nn_dataflow/tests/unit_test/test_scheduling_constraint.py
+++ b/nn_dataflow/tests/unit_test/test_scheduling_constraint.py
@@ -73,20 +73,20 @@ class TestSchedulingConstraint(TestSchedulingConstraintFixture):
     def test_invalid_args(self):
         ''' Invalid arguments. '''
         with self.assertRaisesRegex(ValueError,
-                                     'SchedulingConstraint: '
-                                     '.*positive integers.*'):
+                                    'SchedulingConstraint: '
+                                    '.*positive integers.*'):
             _ = SchedulingConstraint(topbat=-1, topofm=2.)
 
     def test_invalid_update_dict(self):
         ''' Invalid argument update_dict. '''
         with self.assertRaisesRegex(TypeError,
-                                     'SchedulingConstraint: '
-                                     '.*update_dict.*'):
+                                    'SchedulingConstraint: '
+                                    '.*update_dict.*'):
             _ = SchedulingConstraint(update_dict=['l1'])
 
         with self.assertRaisesRegex(TypeError,
-                                     'SchedulingConstraint: '
-                                     '.*update_dict.*'):
+                                    'SchedulingConstraint: '
+                                    '.*update_dict.*'):
             _ = SchedulingConstraint(update_dict={'l1': 1})
 
     def test_null_constraint(self):
@@ -141,13 +141,13 @@ class TestSchedulingConstraint(TestSchedulingConstraintFixture):
             })
 
         with self.assertRaisesRegex(ValueError,
-                                     'SchedulingConstraint: '
-                                     '.*update_dict.*'):
+                                    'SchedulingConstraint: '
+                                    '.*update_dict.*'):
             cstr.is_valid_top_bl([1] * le.NUM, range(le.NUM))
 
         with self.assertRaisesRegex(ValueError,
-                                     'SchedulingConstraint: '
-                                     '.*update_dict.*'):
+                                    'SchedulingConstraint: '
+                                    '.*update_dict.*'):
             cstr.is_valid_part(PartitionScheme(order=range(pe.NUM),
                                                pdims=[(2, 2)] * pe.NUM))
 
@@ -170,9 +170,9 @@ class TestSchedulingConstraint(TestSchedulingConstraintFixture):
         self.assertTrue(set_fgofm.issubset(set(gofm0)))
         self.assertTrue(set_fgbat.issubset(set(gbat0)))
         self.assertSetEqual(set_fgofm,
-                            set([(4,) + tpl for tpl in util.factorize(5, 2)]))
+                            {(4,) + tpl for tpl in util.factorize(5, 2)})
         self.assertSetEqual(set_fgbat,
-                            set([(2,) + tpl for tpl in util.factorize(8, 2)]))
+                            {(2,) + tpl for tpl in util.factorize(8, 2)})
 
         cstr = SchedulingConstraint(topifm=4)
 
@@ -186,7 +186,7 @@ class TestSchedulingConstraint(TestSchedulingConstraintFixture):
         set_fgifm = set(fgifm)
         self.assertTrue(set_fgifm.issubset(set(gifm0)))
         self.assertSetEqual(set_fgifm,
-                            set([(4,) + tpl for tpl in util.factorize(9, 2)]))
+                            {(4,) + tpl for tpl in util.factorize(9, 2)})
 
         cstr = SchedulingConstraint()
 
@@ -288,18 +288,18 @@ class TestSchedulingConstraintLayerPipeline(TestSchedulingConstraintFixture):
     def test_invalid_args(self):
         ''' Invalid arguments. '''
         with self.assertRaisesRegex(ValueError,
-                                     'SchedulingConstraintLayerPipeline: '
-                                     '.*IFM.*'):
+                                    'SchedulingConstraintLayerPipeline: '
+                                    '.*IFM.*'):
             _ = SchedulingConstraintLayerPipeline(topifm=2, fbifm=True)
 
         with self.assertRaisesRegex(ValueError,
-                                     'SchedulingConstraintLayerPipeline: '
-                                     '.*OFM.*'):
+                                    'SchedulingConstraintLayerPipeline: '
+                                    '.*OFM.*'):
             _ = SchedulingConstraintLayerPipeline(topofm=2, fbofm=True)
 
         with self.assertRaisesRegex(ValueError,
-                                     'SchedulingConstraintLayerPipeline: '
-                                     '.*IFM.*OFM.*'):
+                                    'SchedulingConstraintLayerPipeline: '
+                                    '.*IFM.*OFM.*'):
             _ = SchedulingConstraintLayerPipeline(topifm=2, topofm=2)
 
     def test_null_constraint(self):

--- a/nn_dataflow/tests/unit_test/test_scheduling_constraint.py
+++ b/nn_dataflow/tests/unit_test/test_scheduling_constraint.py
@@ -72,19 +72,19 @@ class TestSchedulingConstraint(TestSchedulingConstraintFixture):
 
     def test_invalid_args(self):
         ''' Invalid arguments. '''
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'SchedulingConstraint: '
                                      '.*positive integers.*'):
             _ = SchedulingConstraint(topbat=-1, topofm=2.)
 
     def test_invalid_update_dict(self):
         ''' Invalid argument update_dict. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'SchedulingConstraint: '
                                      '.*update_dict.*'):
             _ = SchedulingConstraint(update_dict=['l1'])
 
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'SchedulingConstraint: '
                                      '.*update_dict.*'):
             _ = SchedulingConstraint(update_dict={'l1': 1})
@@ -140,12 +140,12 @@ class TestSchedulingConstraint(TestSchedulingConstraintFixture):
                 'l2': lambda s, r: setattr(s, 'topifm', r.topifm),
             })
 
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'SchedulingConstraint: '
                                      '.*update_dict.*'):
             cstr.is_valid_top_bl([1] * le.NUM, range(le.NUM))
 
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'SchedulingConstraint: '
                                      '.*update_dict.*'):
             cstr.is_valid_part(PartitionScheme(order=range(pe.NUM),
@@ -287,17 +287,17 @@ class TestSchedulingConstraintLayerPipeline(TestSchedulingConstraintFixture):
 
     def test_invalid_args(self):
         ''' Invalid arguments. '''
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'SchedulingConstraintLayerPipeline: '
                                      '.*IFM.*'):
             _ = SchedulingConstraintLayerPipeline(topifm=2, fbifm=True)
 
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'SchedulingConstraintLayerPipeline: '
                                      '.*OFM.*'):
             _ = SchedulingConstraintLayerPipeline(topofm=2, fbofm=True)
 
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'SchedulingConstraintLayerPipeline: '
                                      '.*IFM.*OFM.*'):
             _ = SchedulingConstraintLayerPipeline(topifm=2, topofm=2)

--- a/nn_dataflow/tests/unit_test/test_scheduling_result.py
+++ b/nn_dataflow/tests/unit_test/test_scheduling_result.py
@@ -71,7 +71,7 @@ class TestSchedulingResult(unittest.TestCase):
     def test_invalid_scheme(self):
         ''' Invalid scheme. '''
         with self.assertRaisesRegex(TypeError,
-                                     'SchedulingResult: .*scheme.*'):
+                                    'SchedulingResult: .*scheme.*'):
             _ = SchedulingResult(scheme={},
                                  ofmap_layout=self.ofmap_layout,
                                  sched_seq=self.sched_seq)
@@ -79,7 +79,7 @@ class TestSchedulingResult(unittest.TestCase):
     def test_invalid_ofmap_layout(self):
         ''' Invalid ofmap_layout. '''
         with self.assertRaisesRegex(TypeError,
-                                     'SchedulingResult: .*ofmap_layout.*'):
+                                    'SchedulingResult: .*ofmap_layout.*'):
             _ = SchedulingResult(scheme=self.scheme,
                                  ofmap_layout=None,
                                  sched_seq=self.sched_seq)
@@ -87,13 +87,13 @@ class TestSchedulingResult(unittest.TestCase):
     def test_invalid_sched_seq(self):
         ''' Invalid sched_seq. '''
         with self.assertRaisesRegex(TypeError,
-                                     'SchedulingResult: .*sched_seq.*'):
+                                    'SchedulingResult: .*sched_seq.*'):
             _ = SchedulingResult(scheme=self.scheme,
                                  ofmap_layout=self.ofmap_layout,
                                  sched_seq=list(self.sched_seq))
 
         with self.assertRaisesRegex(ValueError,
-                                     'SchedulingResult: .*sched_seq.*'):
+                                    'SchedulingResult: .*sched_seq.*'):
             _ = SchedulingResult(scheme=self.scheme,
                                  ofmap_layout=self.ofmap_layout,
                                  sched_seq=self.sched_seq[:-1])

--- a/nn_dataflow/tests/unit_test/test_scheduling_result.py
+++ b/nn_dataflow/tests/unit_test/test_scheduling_result.py
@@ -70,7 +70,7 @@ class TestSchedulingResult(unittest.TestCase):
 
     def test_invalid_scheme(self):
         ''' Invalid scheme. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'SchedulingResult: .*scheme.*'):
             _ = SchedulingResult(scheme={},
                                  ofmap_layout=self.ofmap_layout,
@@ -78,7 +78,7 @@ class TestSchedulingResult(unittest.TestCase):
 
     def test_invalid_ofmap_layout(self):
         ''' Invalid ofmap_layout. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'SchedulingResult: .*ofmap_layout.*'):
             _ = SchedulingResult(scheme=self.scheme,
                                  ofmap_layout=None,
@@ -86,13 +86,13 @@ class TestSchedulingResult(unittest.TestCase):
 
     def test_invalid_sched_seq(self):
         ''' Invalid sched_seq. '''
-        with self.assertRaisesRegexp(TypeError,
+        with self.assertRaisesRegex(TypeError,
                                      'SchedulingResult: .*sched_seq.*'):
             _ = SchedulingResult(scheme=self.scheme,
                                  ofmap_layout=self.ofmap_layout,
                                  sched_seq=list(self.sched_seq))
 
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'SchedulingResult: .*sched_seq.*'):
             _ = SchedulingResult(scheme=self.scheme,
                                  ofmap_layout=self.ofmap_layout,

--- a/nn_dataflow/tests/unit_test/test_util.py
+++ b/nn_dataflow/tests/unit_test/test_util.py
@@ -151,21 +151,43 @@ class TestUtilApproxDividable(unittest.TestCase):
 
     def test_int(self):
         ''' Int. '''
-        self.assertTrue(util.approx_dividable(24, 2, overhead=0))
-        self.assertTrue(util.approx_dividable(24, 3, overhead=0))
-        self.assertTrue(util.approx_dividable(24, 4, overhead=0))
+        self.assertTrue(util.approx_dividable(24, 2,
+                                              rel_overhead=0, abs_overhead=0))
+        self.assertTrue(util.approx_dividable(24, 3,
+                                              rel_overhead=0, abs_overhead=0))
+        self.assertTrue(util.approx_dividable(24, 4,
+                                              rel_overhead=0, abs_overhead=0))
 
         self.assertTrue(util.approx_dividable(11, 2))
-        self.assertFalse(util.approx_dividable(9, 2))
+        self.assertFalse(util.approx_dividable(8, 5))
         self.assertTrue(util.approx_dividable(19, 5))
 
-        self.assertTrue(util.approx_dividable(7, 2, overhead=0.2))
-        self.assertTrue(util.approx_dividable(19, 7, overhead=0.2))
-        self.assertFalse(util.approx_dividable(22, 7, overhead=0.2))
+        self.assertTrue(util.approx_dividable(7, 2,
+                                              rel_overhead=0.2,
+                                              abs_overhead=0))
+        self.assertTrue(util.approx_dividable(7, 2,
+                                              rel_overhead=0,
+                                              abs_overhead=1))
+        self.assertTrue(util.approx_dividable(19, 7,
+                                              rel_overhead=0.2,
+                                              abs_overhead=0))
+        self.assertTrue(util.approx_dividable(19, 7,
+                                              rel_overhead=0,
+                                              abs_overhead=2))
+        self.assertFalse(util.approx_dividable(22, 7,
+                                               rel_overhead=0.2,
+                                               abs_overhead=0))
+        self.assertFalse(util.approx_dividable(23, 7,
+                                               rel_overhead=0,
+                                               abs_overhead=1))
 
-        ovhd = util.idivc(19, 7) * 7 / 19. - 1
-        self.assertFalse(util.approx_dividable(19, 7, overhead=ovhd - 0.01))
-        self.assertTrue(util.approx_dividable(19, 7, overhead=ovhd + 0.01))
+        ovhd = (21 - 19) / max(21., 19.)
+        self.assertFalse(util.approx_dividable(19, 7,
+                                               rel_overhead=ovhd - 0.01,
+                                               abs_overhead=0))
+        self.assertTrue(util.approx_dividable(19, 7,
+                                              rel_overhead=ovhd + 0.01,
+                                              abs_overhead=0))
 
     def test_float(self):
         ''' Float. '''

--- a/nn_dataflow/tests/unit_test/test_util.py
+++ b/nn_dataflow/tests/unit_test/test_util.py
@@ -39,7 +39,7 @@ class TestUtilHashableDict(unittest.TestCase):
 
     def test_fromdict_error(self):
         ''' fromdict error. '''
-        with self.assertRaisesRegexp(TypeError, 'HashableDict: .*dict.*'):
+        with self.assertRaisesRegex(TypeError, 'HashableDict: .*dict.*'):
             _ = util.HashableDict.fromdict([1, 2])
 
     def test_eq(self):
@@ -277,9 +277,9 @@ class TestUtilClosestFactor(unittest.TestCase):
 
     def test_value_float(self):
         ''' Value is float. '''
-        with self.assertRaisesRegexp(TypeError, '.*integers.*'):
+        with self.assertRaisesRegex(TypeError, '.*integers.*'):
             _ = util.closest_factor(24.3, 5)
-        with self.assertRaisesRegexp(TypeError, '.*integers.*'):
+        with self.assertRaisesRegex(TypeError, '.*integers.*'):
             _ = util.closest_factor(24., 10)
 
     def test_factor_float(self):
@@ -294,11 +294,11 @@ class TestUtilClosestFactor(unittest.TestCase):
 
     def test_negative(self):
         ''' Negative. '''
-        with self.assertRaisesRegexp(ValueError, '.*negative.*'):
+        with self.assertRaisesRegex(ValueError, '.*negative.*'):
             _ = util.closest_factor(24, -5)
-        with self.assertRaisesRegexp(ValueError, '.*negative.*'):
+        with self.assertRaisesRegex(ValueError, '.*negative.*'):
             _ = util.closest_factor(-24, -5)
-        with self.assertRaisesRegexp(ValueError, '.*negative.*'):
+        with self.assertRaisesRegex(ValueError, '.*negative.*'):
             _ = util.closest_factor(-24, 5)
 
     def test_missing(self):
@@ -388,36 +388,36 @@ class TestUtilGCD(unittest.TestCase):
 
     def test_float(self):
         ''' Float. '''
-        with self.assertRaisesRegexp(TypeError, '.*integers.*'):
+        with self.assertRaisesRegex(TypeError, '.*integers.*'):
             _ = util.gcd(1., 2)
 
-        with self.assertRaisesRegexp(TypeError, '.*integers.*'):
+        with self.assertRaisesRegex(TypeError, '.*integers.*'):
             _ = util.gcd(1, 2.2)
 
-        with self.assertRaisesRegexp(TypeError, '.*integers.*'):
+        with self.assertRaisesRegex(TypeError, '.*integers.*'):
             _ = util.gcd(1, 2, 3, 4.2)
 
     def test_non_positive(self):
         ''' Non-positive values. '''
-        with self.assertRaisesRegexp(ValueError, '.*positive.*'):
+        with self.assertRaisesRegex(ValueError, '.*positive.*'):
             _ = util.gcd(-1, 2)
 
-        with self.assertRaisesRegexp(ValueError, '.*positive.*'):
+        with self.assertRaisesRegex(ValueError, '.*positive.*'):
             _ = util.gcd(1, -2)
 
-        with self.assertRaisesRegexp(ValueError, '.*positive.*'):
+        with self.assertRaisesRegex(ValueError, '.*positive.*'):
             _ = util.gcd(3, 6, 9, 12, -21)
 
-        with self.assertRaisesRegexp(ValueError, '.*positive.*'):
+        with self.assertRaisesRegex(ValueError, '.*positive.*'):
             _ = util.gcd(3, 0)
 
-        with self.assertRaisesRegexp(ValueError, '.*positive.*'):
+        with self.assertRaisesRegex(ValueError, '.*positive.*'):
             _ = util.gcd(0, 3)
 
-        with self.assertRaisesRegexp(ValueError, '.*positive.*'):
+        with self.assertRaisesRegex(ValueError, '.*positive.*'):
             _ = util.gcd(0, 5, 10, 15, 20)
 
-        with self.assertRaisesRegexp(ValueError, '.*positive.*'):
+        with self.assertRaisesRegex(ValueError, '.*positive.*'):
             _ = util.gcd(5, 10, 0, 15, 20)
 
 
@@ -449,36 +449,36 @@ class TestUtilLCM(unittest.TestCase):
 
     def test_float(self):
         ''' Float. '''
-        with self.assertRaisesRegexp(TypeError, '.*integers.*'):
+        with self.assertRaisesRegex(TypeError, '.*integers.*'):
             _ = util.lcm(1., 2)
 
-        with self.assertRaisesRegexp(TypeError, '.*integers.*'):
+        with self.assertRaisesRegex(TypeError, '.*integers.*'):
             _ = util.lcm(1, 2.2)
 
-        with self.assertRaisesRegexp(TypeError, '.*integers.*'):
+        with self.assertRaisesRegex(TypeError, '.*integers.*'):
             _ = util.lcm(1, 2, 3, 4.2)
 
     def test_non_positive(self):
         ''' Non-positive values. '''
-        with self.assertRaisesRegexp(ValueError, '.*positive.*'):
+        with self.assertRaisesRegex(ValueError, '.*positive.*'):
             _ = util.lcm(-1, 2)
 
-        with self.assertRaisesRegexp(ValueError, '.*positive.*'):
+        with self.assertRaisesRegex(ValueError, '.*positive.*'):
             _ = util.lcm(1, -2)
 
-        with self.assertRaisesRegexp(ValueError, '.*positive.*'):
+        with self.assertRaisesRegex(ValueError, '.*positive.*'):
             _ = util.lcm(3, 6, 9, 12, -21)
 
-        with self.assertRaisesRegexp(ValueError, '.*positive.*'):
+        with self.assertRaisesRegex(ValueError, '.*positive.*'):
             _ = util.lcm(3, 0)
 
-        with self.assertRaisesRegexp(ValueError, '.*positive.*'):
+        with self.assertRaisesRegex(ValueError, '.*positive.*'):
             _ = util.lcm(0, 3)
 
-        with self.assertRaisesRegexp(ValueError, '.*positive.*'):
+        with self.assertRaisesRegex(ValueError, '.*positive.*'):
             _ = util.lcm(0, 5, 10, 15, 20)
 
-        with self.assertRaisesRegexp(ValueError, '.*positive.*'):
+        with self.assertRaisesRegex(ValueError, '.*positive.*'):
             _ = util.lcm(5, 10, 0, 15, 20)
 
 
@@ -535,10 +535,10 @@ class TestUtilAssertFloatEqInt(unittest.TestCase):
 
     def test_fail(self):
         ''' Fail. '''
-        with self.assertRaisesRegexp(AssertionError, '.*12.*'):
+        with self.assertRaisesRegex(AssertionError, '.*12.*'):
             util.assert_float_eq_int(13.01, 12)
-        with self.assertRaisesRegexp(AssertionError, '.*12.*'):
+        with self.assertRaisesRegex(AssertionError, '.*12.*'):
             util.assert_float_eq_int(10.99, 12)
-        with self.assertRaisesRegexp(AssertionError, '.*12.*'):
+        with self.assertRaisesRegex(AssertionError, '.*12.*'):
             util.assert_float_eq_int(12., -12)
 

--- a/nn_dataflow/tools/nn_dataflow_search.py
+++ b/nn_dataflow/tools/nn_dataflow_search.py
@@ -96,11 +96,11 @@ def do_scheduling(args):
     dim_array = PhyDim2(*args.array)
 
     # Sizes of gbuf and regf are in words.
-    word = (args.word + 7) / 8
-    size_gbuf = args.gbuf / word
-    size_regf = args.regf / word
+    word = (args.word + 7) // 8
+    size_gbuf = args.gbuf // word
+    size_regf = args.regf // word
 
-    array_bus_width = args.bus_width // args.word
+    array_bus_width = args.bus_width / args.word
     if not array_bus_width:
         array_bus_width = float('inf')
     dram_bandwidth = args.dram_bw / word
@@ -307,7 +307,7 @@ def argparser():
     ap.add_argument('-t', '--top', type=int, default=1,
                     help='Number of top schedules to keep during search.')
     ap.add_argument('-p', '--processes', type=int,
-                    default=multiprocessing.cpu_count()/2,
+                    default=multiprocessing.cpu_count()//2,
                     help='Number of parallel processes to use for search.')
     ap.add_argument('-v', '--verbose', action='store_true',
                     help='Show progress and details.')

--- a/nn_dataflow/tools/nn_dataflow_search.py
+++ b/nn_dataflow/tools/nn_dataflow_search.py
@@ -100,7 +100,7 @@ def do_scheduling(args):
     size_gbuf = args.gbuf // word
     size_regf = args.regf // word
 
-    array_bus_width = args.bus_width / args.word
+    array_bus_width = args.bus_width // args.word
     if not array_bus_width:
         array_bus_width = float('inf')
     dram_bandwidth = args.dram_bw / word

--- a/nn_dataflow/util.py
+++ b/nn_dataflow/util.py
@@ -123,10 +123,14 @@ def prod(lst):
     return reduce(mul, lst, 1)
 
 
-def approx_dividable(total, num, overhead=0.1):
+def approx_dividable(total, num, rel_overhead=0.1, abs_overhead=1):
     ''' Whether it is reasonable to divide `total` into `num` parts.
-    `overhead` is the allowed max padding overhead.  '''
-    return idivc(total, num) * num <= total * (1 + overhead)
+    `rel_overhead` is the allowed max padding overhead measured
+    relatively; `abs_overhead` is the allowed max padding
+    overhead measured by absolute value.'''
+    return total >= num and isclose(
+        idivc(total, num) * num, total,
+        rel_tol=rel_overhead, abs_tol=abs_overhead)
 
 
 def factorize(value, num, limits=None):

--- a/nn_dataflow/util.py
+++ b/nn_dataflow/util.py
@@ -13,6 +13,7 @@ You should have received a copy of the Modified BSD-3 License along with this
 program. If not, see <https://opensource.org/licenses/BSD-3-Clause>.
 """
 
+from functools import reduce
 import math
 from operator import mul
 
@@ -215,8 +216,8 @@ def get_ith_range(rng, idx, num):
     Divide the full range `rng` into `num` parts, and get the `idx`-th range.
     '''
     length = rng[1] - rng[0]
-    beg = rng[0] + idx * length / num
-    end = rng[0] + (idx + 1) * length / num
+    beg = rng[0] + idx * length // num
+    end = rng[0] + (idx + 1) * length // num
     assert end <= rng[1]
     return beg, end
 

--- a/nn_dataflow/util.py
+++ b/nn_dataflow/util.py
@@ -21,7 +21,7 @@ from operator import mul
 Utilities.
 '''
 
-class ContentHashClass(object):
+class ContentHashClass():
     '''
     Class using the content instead of the object ID for hash.
 

--- a/nn_dataflow/util.py
+++ b/nn_dataflow/util.py
@@ -163,9 +163,8 @@ def factorize(value, num, limits=None):
             factors[lvl] += 1
             if prod(factors[:lvl+1]) <= value:
                 break
-            else:
-                factors[lvl] = 1
-                lvl -= 1
+            factors[lvl] = 1
+            lvl -= 1
         if lvl < 0:
             return
 

--- a/nn_dataflow/util.py
+++ b/nn_dataflow/util.py
@@ -281,3 +281,9 @@ def assert_float_eq_int(vfloat, vint, message=''):
     if abs(vfloat - vint) > 1:
         raise AssertionError(message + ' {} != {}'.format(vfloat, vint))
 
+def apply(func, argv):
+    '''
+    Similar to python2 built-in apply function.
+    '''
+    return func(*argv)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 argparse
-coverage==4.4.1
-fastcache==1.0.2
-pytest==3.1.2
-pytest-cov==2.5.1
-pytest-xdist==1.17.1
-sympy==1.2.0
+coverage==5.0
+fastcache==1.1.0
+pytest==5.3.2
+pytest-cov==2.8.1
+pytest-xdist==1.30.0
+sympy==1.4


### PR DESCRIPTION
Port code to Python3.
[nns] Add ResNet-50 NN model.
[NNDataflow] Share the same partition between input layer and external layers. For layered LSTMs, the number of external layers could be quite a few (e.g., 8). The complete combination of all partition choices of these external layers is too high to explore. So we assume all input and external layers share the same partition scheme.
[util] Allow both relative and absolute overheads in approx_dividable.
[LoopBlockingScheme] Bug fix to put weight-pinning code block after buffer sharing.